### PR TITLE
Expose monit admin user as env var

### DIFF
--- a/scripts/dockerfiles/monitrc.erb
+++ b/scripts/dockerfiles/monitrc.erb
@@ -7,7 +7,7 @@ set logfile /var/vcap/monit/monit.log
 # provided by the user. We're afraid of exposing writable access to remote clients
 # using a non-TLS enabled connection.
 set httpd port <%= p("hcf.monit.port") %> and use address 0.0.0.0
-  allow "<%= SecureRandom.hex %>":"<%= SecureRandom.hex %>"
+  allow "<%= p("hcf.monit.admin_user") %>":"<%= p("hcf.monit.admin_password") %>"
   allow "<%= p("hcf.monit.user") %>":"<%= p("hcf.monit.password") %>" read-only
 
 include /etc/monit/monitrc.d/cron

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -22,6 +22,8 @@ fi
 
 export IP_ADDRESS=$(/bin/hostname -i | awk '{print $1}')
 export DNS_RECORD_NAME=$(/bin/hostname)
+export MONIT_ADMIN_USER=$(cat /proc/sys/kernel/random/uuid)
+export MONIT_ADMIN_PASSWORD=$(cat /proc/sys/kernel/random/uuid)
 
 # Run custom environment scripts (that are sourced)
 {{ range $script := .role.EnvironScripts }}


### PR DESCRIPTION
We need the admin user in the galera bootstrap job. 
The currently used "admin" user does not have permissions to restart the mysql process.