### PR TITLE
Make compile-without-docker detection stricter

### DIFF
--- a/scripts/compilation/ubuntu-compile.sh
+++ b/scripts/compilation/ubuntu-compile.sh
@@ -16,9 +16,9 @@ if test -z "${packageVersion}" ; then
   usage version
 fi
 
-if test -d "/fissile-in" ; then
+if test -d "/fissile-in/var/vcap" ; then
   mkdir -p "/var/vcap"
-  cp -r /fissile-in/var/vcap/* /var/vcap
+  cp -r "/fissile-in/var/vcap/"* /var/vcap
 else
   # Running new in new mount ns
   buildroot="${3:-}"


### PR DESCRIPTION
We need to use the fissile-built compilation image to actually build anything; however, that image already has a `/fissile-in` directory (because that's how the script to build the image was dropped in there). So we need to actually check for `/fissile-in/var/vcap` to know if we're building in docker.