### PR TITLE
Make k8s probe timeouts configurable from role manifest

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -267,6 +267,14 @@ func getContainerLivenessProbe(role *model.Role) *v1.Probe {
 
 	switch role.Type {
 	case model.RoleTypeBosh:
+		var timeout int32 = 1
+		if role.Run != nil &&
+			role.Run.HealthCheck != nil &&
+			role.Run.HealthCheck.Liveness != nil &&
+			role.Run.HealthCheck.Liveness.Timeout > 0 {
+			timeout = role.Run.HealthCheck.Liveness.Timeout
+		}
+
 		return &v1.Probe{
 			Handler: v1.Handler{
 				TCPSocket: &v1.TCPSocketAction{
@@ -275,6 +283,7 @@ func getContainerLivenessProbe(role *model.Role) *v1.Probe {
 			},
 			// TODO: make this configurable (figure out where the knob should live)
 			InitialDelaySeconds: 600,
+			TimeoutSeconds:      timeout,
 		}
 	default:
 		return nil
@@ -294,9 +303,17 @@ func getContainerReadinessProbe(role *model.Role) (*v1.Probe, error) {
 	if role.Run == nil {
 		return nil, nil
 	}
+
+	var timeout int32 = 1
+
 	if role.Run.HealthCheck != nil {
+		if role.Run.HealthCheck.Readiness != nil &&
+			role.Run.HealthCheck.Readiness.Timeout > 0 {
+			timeout = role.Run.HealthCheck.Readiness.Timeout
+		}
+
 		if role.Run.HealthCheck.URL != "" {
-			return getContainerURLReadinessProbe(role)
+			return getContainerURLReadinessProbe(role, timeout)
 		}
 		if role.Run.HealthCheck.Port != 0 {
 			return &v1.Probe{
@@ -305,6 +322,7 @@ func getContainerReadinessProbe(role *model.Role) (*v1.Probe, error) {
 						Port: intstr.FromInt(int(role.Run.HealthCheck.Port)),
 					},
 				},
+				TimeoutSeconds: timeout,
 			}, nil
 		}
 		if len(role.Run.HealthCheck.Command) > 0 {
@@ -314,6 +332,7 @@ func getContainerReadinessProbe(role *model.Role) (*v1.Probe, error) {
 						Command: role.Run.HealthCheck.Command,
 					},
 				},
+				TimeoutSeconds: timeout,
 			}, nil
 		}
 	}
@@ -341,13 +360,14 @@ func getContainerReadinessProbe(role *model.Role) (*v1.Probe, error) {
 					Port: intstr.FromInt(int(probePort)),
 				},
 			},
+			TimeoutSeconds: timeout,
 		}, nil
 	default:
 		return nil, nil
 	}
 }
 
-func getContainerURLReadinessProbe(role *model.Role) (*v1.Probe, error) {
+func getContainerURLReadinessProbe(role *model.Role, timeout int32) (*v1.Probe, error) {
 	probeURL, err := url.Parse(role.Run.HealthCheck.URL)
 	if err != nil {
 		return nil, fmt.Errorf("Invalid URL health check for %s: %s", role.Name, err)
@@ -412,6 +432,7 @@ func getContainerURLReadinessProbe(role *model.Role) (*v1.Probe, error) {
 				HTTPHeaders: headers,
 			},
 		},
+		TimeoutSeconds: timeout,
 	}, nil
 }
 

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -267,7 +267,7 @@ func getContainerLivenessProbe(role *model.Role) *v1.Probe {
 
 	switch role.Type {
 	case model.RoleTypeBosh:
-		var timeout int32 = 1
+		var timeout int32
 		if role.Run != nil &&
 			role.Run.HealthCheck != nil &&
 			role.Run.HealthCheck.Liveness != nil &&
@@ -304,7 +304,7 @@ func getContainerReadinessProbe(role *model.Role) (*v1.Probe, error) {
 		return nil, nil
 	}
 
-	var timeout int32 = 1
+	var timeout int32
 
 	if role.Run.HealthCheck != nil {
 		if role.Run.HealthCheck.Readiness != nil &&

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -256,6 +256,15 @@ func getSecurityContext(role *model.Role) *v1.SecurityContext {
 }
 
 func getContainerLivenessProbe(role *model.Role) *v1.Probe {
+	// Ref https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configuring-probes
+	// Ref vendor/k8s.io/client-go/pkg/api/v1/types.go (1297ff)
+	//
+	// InitialDelaySeconds -
+	// TimeoutSeconds      - 1, min 1
+	// PeriodSeconds       - 10, min 1 (interval between probes)
+	// SuccessThreshold    - 1 (default, must be this value for liveness probe)
+	// FailureThreshold    - 3, min 1
+
 	switch role.Type {
 	case model.RoleTypeBosh:
 		return &v1.Probe{
@@ -273,6 +282,15 @@ func getContainerLivenessProbe(role *model.Role) *v1.Probe {
 }
 
 func getContainerReadinessProbe(role *model.Role) (*v1.Probe, error) {
+	// Ref https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configuring-probes
+	// Ref vendor/k8s.io/client-go/pkg/api/v1/types.go (1297ff)
+	//
+	// InitialDelaySeconds -
+	// TimeoutSeconds      - 1, min 1
+	// PeriodSeconds       - 10, min 1 (interval between probes)
+	// SuccessThreshold    - 1, min 1 (must be 1 for liveness probe)
+	// FailureThreshold    - 3, min 1
+
 	if role.Run == nil {
 		return nil, nil
 	}

--- a/make/vet
+++ b/make/vet
@@ -2,4 +2,10 @@
 
 set -o errexit
 
+. make/include/colors.sh
+
+printf "%b==> Vetting %b\n" "${OK_COLOR}" "${ERROR_COLOR}"
+
 go vet $(go list -f '{{ .ImportPath }}' ./... | sed '\@fissile/scripts@d ; \@fissile/mustache@d ; \@/vendor/@d')
+
+printf "%b" "${NO_COLOR}"

--- a/model/roles.go
+++ b/model/roles.go
@@ -100,10 +100,18 @@ type RoleRunExposedPort struct {
 
 // HealthCheck describes a non-standard health check endpoint
 type HealthCheck struct {
-	URL     string            `yaml:"url"`     // URL for a HTTP GET to return 200~399. Cannot be used with other checks.
-	Headers map[string]string `yaml:"headers"` // Custom headers; only used for URL.
-	Command []string          `yaml:"command"` // Custom command. Cannot be used with other checks.
-	Port    int32             `yaml:"port"`    // Port for a TCP probe. Cannot be used with other checks.
+	URL       string            `yaml:"url"`                 // URL for a HTTP GET to return 200~399. Cannot be used with other checks.
+	Headers   map[string]string `yaml:"headers"`             // Custom headers; only used for URL.
+	Command   []string          `yaml:"command"`             // Custom command. Cannot be used with other checks.
+	Port      int32             `yaml:"port"`                // Port for a TCP probe. Cannot be used with other checks.
+	Liveness  *HealthProbe      `yaml:"liveness,omitempty"`  // Details of liveness probe configuration
+	Readiness *HealthProbe      `yaml:"readiness,omitempty"` // Ditto for readiness probe
+}
+
+// HealthProbe holds the configuration for liveness and readiness
+// probes based on the HealthCheck containing them.
+type HealthProbe struct {
+	Timeout int32 `yaml:"timeout,omitempty"` // Timeout in seconds, default 3, minimum 1
 }
 
 // Roles is an array of Role*


### PR DESCRIPTION
Trello: https://trello.com/c/yVo0iMIM/119-3-fissile-should-have-a-timeout-setting-for-readiness-probes-and-other-probes-too-probably
