### PR TITLE
Trigger rebuild for fissile version changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ scripts/dockerfiles/dockerfiles.go
 scripts/templates/transformations.go
 *_generated.go
 *~
+*/*.test
 /test-assets/*/.dev_builds
 /test-assets/*/.blobs

--- a/builder/packages_image.go
+++ b/builder/packages_image.go
@@ -109,6 +109,10 @@ func (w *tarWalker) walk(path string, info os.FileInfo, err error) error {
 	return err
 }
 
+func (p *PackagesImageBuilder) fissileVersionLabel() string {
+	return fmt.Sprintf("version.generator.fissile=%s", p.fissileVersion)
+}
+
 // determinePackagesLayerBaseImage finds the best base image to use for the
 // packages layer image.  Given a list of packages, it returns the base image
 // name to use, as well as the set of packages that still need to be inserted.
@@ -224,8 +228,9 @@ func (p *PackagesImageBuilder) NewDockerPopulator(roles model.Roles, forceBuildA
 // generateDockerfile builds a docker file for the shared packages layer.
 func (p *PackagesImageBuilder) generateDockerfile(baseImage string, packages model.Packages, outputFile io.Writer) error {
 	context := map[string]interface{}{
-		"base_image": baseImage,
-		"packages":   packages,
+		"base_image":      baseImage,
+		"packages":        packages,
+		"fissile_version": p.fissileVersionLabel(),
 	}
 	asset, err := dockerfiles.Asset("Dockerfile-packages")
 	if err != nil {

--- a/builder/packages_image.go
+++ b/builder/packages_image.go
@@ -129,11 +129,16 @@ func (p *PackagesImageBuilder) determinePackagesLayerBaseImage(packages model.Pa
 		remainingPackages[pkg.Fingerprint] = pkg
 	}
 
+	var mandatoryLabels = []string{
+		p.fissileVersionLabel(),
+	}
+
 	dockerManger, err := docker.NewImageManager()
 	if err != nil {
 		return "", nil, err
 	}
-	matchedImage, foundLabels, err := dockerManger.FindBestImageWithLabels(baseImageName, labels)
+	matchedImage, foundLabels, err := dockerManger.FindBestImageWithLabels(baseImageName,
+		labels, mandatoryLabels)
 	if err != nil {
 		return "", nil, err
 	}
@@ -142,7 +147,7 @@ func (p *PackagesImageBuilder) determinePackagesLayerBaseImage(packages model.Pa
 	for label := range foundLabels {
 		parts := strings.Split(label, ".")
 		if len(parts) != 2 || parts[0] != "fingerprint" {
-			// Should never reach here...
+			// Will reach this for mandatory matched labels, i.e. fissile version
 			continue
 		}
 		delete(remainingPackages, parts[1])

--- a/builder/packages_image_test.go
+++ b/builder/packages_image_test.go
@@ -77,6 +77,7 @@ func TestGenerateDockerfile(t *testing.T) {
 	assert.Equal([]string{
 		"FROM scratch:latest",
 		"ADD packages-src /var/vcap/packages-src/",
+		"LABEL version.generator.fissile=3.14.15",
 	}, lines, "Unexpected dockerfile contents found")
 }
 
@@ -140,7 +141,12 @@ func TestNewDockerPopulator(t *testing.T) {
 			var line string
 			testers := []func(){
 				func() { assert.Equal(fmt.Sprintf("FROM %s", baseImage.ID), line, "line 1 should start with FROM") },
-				func() { assert.Equal("ADD packages-src /var/vcap/packages-src/", line, "line 3 mismatch") },
+				func() {
+					assert.Equal("ADD packages-src /var/vcap/packages-src/", line, "line 3 mismatch (ADD, package src location)")
+				},
+				func() {
+					assert.Equal("LABEL version.generator.fissile=3.14.15", line, "line 4 mismatch (LABEL, generator version)")
+				},
 				func() {
 					expected := []string{
 						"LABEL",

--- a/scripts/dockerfiles/Dockerfile-packages
+++ b/scripts/dockerfiles/Dockerfile-packages
@@ -2,6 +2,7 @@ FROM {{ index . "base_image" }}
 
 ADD packages-src /var/vcap/packages-src/
 
+LABEL {{ index . "fissile_version" }}
 {{ if .packages }}
 LABEL {{ range .packages }} "fingerprint.{{.Fingerprint}}"="{{.Name}}" {{ end }}
 {{ end }}


### PR DESCRIPTION
Trello: https://trello.com/c/nKVdKHnE/147-fissile-version-change-no-longer-triggers-image-rebuild

Has https://github.com/SUSE/fissile/pull/240 stacked on top, same area of fissile, tested together
