### PR TITLE
kube: switch job api namespace to batch/v1 (k8s 1.6)

### DIFF
--- a/kube/job.go
+++ b/kube/job.go
@@ -32,7 +32,7 @@ func NewJob(role *model.Role, settings *ExportSettings) (*extra.Job, error) {
 
 	return &extra.Job{
 		TypeMeta: meta.TypeMeta{
-			APIVersion: "extensions/v1beta1",
+			APIVersion: "batch/v1",
 			Kind:       "Job",
 		},
 		ObjectMeta: apiv1.ObjectMeta{


### PR DESCRIPTION
This is for compatibility with kubernetes 1.6; otherwise things don't deploy.  For some reason we don't need to touch deployment for now.