### PR TITLE
Emit manifest secrets as K8s secrets, not as env vars.

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -729,7 +729,7 @@ func (f *Fissile) GenerateKube(rolesManifestPath, outputDir, repository, registr
 		}
 	}
 	// cvs now holds only the secrets.
-	thesecrets, therefs, err := kube.MakeSecrets(cvs, defaults)
+	secrets, refs, err := kube.MakeSecrets(cvs, defaults)
 	if err != nil {
 		return err
 	}
@@ -741,7 +741,7 @@ func (f *Fissile) GenerateKube(rolesManifestPath, outputDir, repository, registr
 		return err
 	}
 
-	for _, secret := range thesecrets {
+	for _, secret := range secrets {
 		outputPath := filepath.Join(secretsDir, fmt.Sprintf("%s.yml", secret.ObjectMeta.Name))
 		f.UI.Printf("Writing config %s for secret %s\n",
 			color.CyanString(outputPath),
@@ -769,7 +769,7 @@ func (f *Fissile) GenerateKube(rolesManifestPath, outputDir, repository, registr
 		UseMemoryLimits: useMemoryLimits,
 		FissileVersion:  fissileVersion,
 		Opinions:        opinions,
-		Secrets:         therefs,
+		Secrets:         refs,
 	}
 
 	for _, role := range rolesManifest.Roles {

--- a/kube/export_settings.go
+++ b/kube/export_settings.go
@@ -13,4 +13,5 @@ type ExportSettings struct {
 	UseMemoryLimits bool
 	FissileVersion  string
 	Opinions        *model.Opinions
+	Secrets         RefMap
 }

--- a/kube/export_settings.go
+++ b/kube/export_settings.go
@@ -13,5 +13,5 @@ type ExportSettings struct {
 	UseMemoryLimits bool
 	FissileVersion  string
 	Opinions        *model.Opinions
-	Secrets         RefMap
+	Secrets         SecretRefMap
 }

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -186,6 +186,11 @@ func getEnvVars(role *model.Role, defaults map[string]string) ([]v1.EnvVar, erro
 	result := make([]v1.EnvVar, 0, len(configs))
 
 	for _, config := range configs {
+		// Skip secrets, we emit them at XXX as proper such.
+		if config.Secret {
+			continue
+		}
+
 		var value interface{}
 
 		value = config.Default

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -176,7 +176,7 @@ func getVolumeMounts(role *model.Role) []v1.VolumeMount {
 	return result
 }
 
-func getEnvVars(role *model.Role, defaults map[string]string, secrets RefMap) ([]v1.EnvVar, error) {
+func getEnvVars(role *model.Role, defaults map[string]string, secrets SecretRefMap) ([]v1.EnvVar, error) {
 	configs, err := role.GetVariablesForRole()
 
 	if err != nil {

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -179,8 +179,14 @@ func TestPodGetEnvVars(t *testing.T) {
 			"ALL_VAR":    "placeholder",
 			"SECRET_VAR": "the-secret",
 		}
+		secrets := RefMap{
+			"SECRET_VAR": Ref{
+				Secret: "secret-1",
+				Key:    "secret-var",
+			},
+		}
 
-		vars, err := getEnvVars(role, defaults)
+		vars, err := getEnvVars(role, defaults, secrets)
 		assert.NoError(err)
 		assert.NotEmpty(vars)
 
@@ -201,7 +207,7 @@ func TestPodGetEnvVars(t *testing.T) {
 		}
 		assert.True(founda, "failed to find expected variable SOME_VAR")
 		assert.True(foundb, "failed to find expected variable ALL_VAR")
-		assert.False(foundc, "unexpectedly found secret variable SECRET_VAR")
+		assert.True(foundc, "failed to find secret variable SECRET_VAR")
 	}
 }
 

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -203,6 +203,8 @@ func TestPodGetEnvVars(t *testing.T) {
 			}
 			if result.Name == "SECRET_VAR" {
 				foundc = true
+				assert.Equal("secret-var", result.ValueFrom.SecretKeyRef.Key)
+				assert.Equal("secret-1", result.ValueFrom.SecretKeyRef.LocalObjectReference.Name)
 			}
 		}
 		assert.True(founda, "failed to find expected variable SOME_VAR")

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -179,8 +179,8 @@ func TestPodGetEnvVars(t *testing.T) {
 			"ALL_VAR":    "placeholder",
 			"SECRET_VAR": "the-secret",
 		}
-		secrets := RefMap{
-			"SECRET_VAR": Ref{
+		secrets := SecretRefMap{
+			"SECRET_VAR": SecretRef{
 				Secret: "secret-1",
 				Key:    "secret-var",
 			},

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -43,6 +43,16 @@ func podTestLoadRole(assert *assert.Assertions) *model.Role {
 		return nil
 	}
 
+	// Force a broadcast SECRET_VAR into the manifest, to see in all roles
+	manifest.Configuration.Variables =
+		append(manifest.Configuration.Variables,
+			&model.ConfigurationVariable{
+				Name:     "SECRET_VAR",
+				Type:     model.CVTypeUser,
+				Secret:   true,
+				Internal: true,
+			})
+
 	return role
 }
 
@@ -165,8 +175,9 @@ func TestPodGetEnvVars(t *testing.T) {
 
 	for _, sample := range samples {
 		defaults := map[string]string{
-			"SOME_VAR": sample.input,
-			"ALL_VAR":  "placeholder",
+			"SOME_VAR":   sample.input,
+			"ALL_VAR":    "placeholder",
+			"SECRET_VAR": "the-secret",
 		}
 
 		vars, err := getEnvVars(role, defaults)
@@ -175,6 +186,7 @@ func TestPodGetEnvVars(t *testing.T) {
 
 		founda := false
 		foundb := false
+		foundc := false
 		for _, result := range vars {
 			if result.Name == "SOME_VAR" {
 				founda = true
@@ -183,9 +195,13 @@ func TestPodGetEnvVars(t *testing.T) {
 			if result.Name == "ALL_VAR" {
 				foundb = true
 			}
+			if result.Name == "SECRET_VAR" {
+				foundc = true
+			}
 		}
 		assert.True(founda, "failed to find expected variable SOME_VAR")
 		assert.True(foundb, "failed to find expected variable ALL_VAR")
+		assert.False(foundc, "unexpectedly found secret variable SECRET_VAR")
 	}
 }
 

--- a/kube/secret.go
+++ b/kube/secret.go
@@ -1,0 +1,101 @@
+package kube
+
+import (
+	"fmt"
+	//	"strconv"
+	"strings"
+
+	"github.com/SUSE/fissile/model"
+	meta "k8s.io/client-go/pkg/api/unversioned"
+	apiv1 "k8s.io/client-go/pkg/api/v1"
+)
+
+// NewSecret creates a single new, empty K8s Secret
+func NewSecret(name string) *apiv1.Secret {
+	secret := &apiv1.Secret{
+		TypeMeta: meta.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: apiv1.ObjectMeta{
+			Name: name,
+		},
+	}
+	secret.Data = make(map[string][]byte)
+	return secret
+}
+
+// Ref is an entry in the RefMap
+type Ref struct {
+	Secret string
+	Key    string
+}
+
+// RefMap maps the names of secret CVs to the combination of secret
+// and key used to store their value. Note that the key has to be
+// stored, because of the transformation at (**). Ok, not truly, but
+// then we would have to replicate the transform at the place where
+// the mapping is used. I prefer to do it only once.
+type RefMap map[string]Ref
+
+// MakeSecrets creates an array of new Secrets filled with the
+// key/value pairs from the specified map. It further returns a map
+// showing which original CV name maps to what secret+key combination.
+func MakeSecrets(secrets model.CVMap, defaults map[string]string) ([]*apiv1.Secret, RefMap, error) {
+	var thesecrets []*apiv1.Secret
+	refs := make(map[string]Ref)
+
+	max := apiv1.MaxSecretSize
+	count := 1
+	current := NewSecret(fmt.Sprintf("secret-%d", count))
+	total := 0 // Accumulated size of the values stored in 'current'
+
+	for key, value := range secrets {
+		ok, strValue := configValue(value, defaults)
+		if !ok {
+			return nil, nil, fmt.Errorf("Secret '%s' has no value", key)
+		}
+
+		bytes := []byte(strValue)
+		blen := len(bytes)
+
+		// Bad: This single of our secrets overflows the K8s
+		// limit. We cannot store this.
+		if blen > max {
+			return nil, nil, fmt.Errorf("Secret '%s' overflows K8s limit of %d bytes",
+				key, max)
+		}
+		// The current entry's value overflows the current K8s
+		// secret. Finalize it, and open a new one to store
+		// the current entry and anything after.
+		if total+blen > max {
+			thesecrets = append(thesecrets, current)
+			count = count + 1
+			current = NewSecret(fmt.Sprintf("secret-%d", count))
+			total = 0
+		}
+
+		// (**) From the old transformer we know that "secrets
+		// currently need to be lowercase and can only use
+		// dashes, not underscores"
+		//--
+		// name.downcase!.gsub!('_', '-') if var['secret']
+		//--
+		// Here it is the keys this applies to.
+
+		skey := strings.ToLower(strings.Replace(key, "_", "-", -1))
+
+		current.Data[skey] = bytes
+		refs[key] = Ref{
+			Secret: current.ObjectMeta.Name,
+			Key:    skey,
+		}
+		total = total + blen
+	}
+
+	// Save the last K8s secret. Note that it will contain at
+	// least one entry, by definition / construction.
+	thesecrets = append(thesecrets, current)
+
+	return thesecrets, refs, nil
+}

--- a/model/roles.go
+++ b/model/roles.go
@@ -151,6 +151,7 @@ type ConfigurationVariable struct {
 	Generator   *ConfigurationVariableGenerator `yaml:"generator"`
 	Type        CVType                          `yaml:"type"`
 	Internal    bool                            `yaml:"internal,omitempty"`
+	Secret      bool                            `yaml:"secret,omitempty"`
 }
 
 // CVType is the type of the configuration variable; see the constants below


### PR DESCRIPTION
Trello https://trello.com/c/tk6NUmwT/85-3-k8s-secrets-should-be-secrets-not-env-vars

This change reworks the handling of the CVs marked secret in the manifest.

1. All manifest secrets are emitted as key/value-pairs inside of one or more K8s secrets (*)
2. When emitting the EV for CVs the secret CVs do not emit their value, but a reference to their secret+key from step 1. K8s then (should) arranges for the EV to have the value from the secret, without any intervention needed in manifest scripts and the like.

(Ad *) A K8s "secret" is a mini key/value database, i.e. a single K8s secret can hold multiple manifest secrets. Multiple K8s secrets come into play when the values from the manifest secrets together are larger than the storage limit on K8s secrets, currently 1MB (See `MaxSecretSize`). In that case the manifest secrets are split across as just as many K8s secrets needed to hold them and stay under that limit (**).

(Ad **) The secrets from the SCF manifest currently need a 244K yaml file for storage, which is base64 encoded, actual size should be around 180K, so only a single secret is needed and used.



