### PR TITLE
Add verbose option with caching details

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -73,16 +73,32 @@ func (f *Fissile) ListPackages(verbose bool) error {
 }
 
 // ListJobs will list all jobs within a list of dev releases
-func (f *Fissile) ListJobs() error {
+func (f *Fissile) ListJobs(verbose bool) error {
 	if len(f.releases) == 0 {
 		return fmt.Errorf("Releases not loaded")
 	}
 
 	for _, release := range f.releases {
-		f.UI.Println(color.GreenString("Dev release %s (%s)", color.YellowString(release.Name), color.MagentaString(release.Version)))
+		var releasePath string
+
+		if verbose {
+			releasePath = color.WhiteString(" (%s)", release.Path)
+		}
+
+		f.UI.Println(color.GreenString("Dev release %s (%s)%s", color.YellowString(release.Name), color.MagentaString(release.Version), releasePath))
 
 		for _, job := range release.Jobs {
-			f.UI.Printf("%s (%s): %s\n", color.YellowString(job.Name), color.WhiteString(job.Version), job.Description)
+			var isCached string
+
+			if verbose {
+				if _, err := os.Stat(job.Path); err == nil {
+					isCached = color.WhiteString(" (cached at %s)", job.Path)
+				} else {
+					isCached = color.RedString(" (cache not found)")
+				}
+			}
+
+			f.UI.Printf("%s (%s)%s: %s\n", color.YellowString(job.Name), color.WhiteString(job.Version), isCached, job.Description)
 		}
 
 		f.UI.Printf(

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -47,14 +47,20 @@ func (f *Fissile) ListPackages(verbose bool) error {
 	}
 
 	for _, release := range f.releases {
-		f.UI.Println(color.GreenString("Dev release %s (%s)", color.YellowString(release.Name), color.MagentaString(release.Version)))
+		var releasePath string
+
+		if verbose {
+			releasePath = color.WhiteString(" (%s)", release.Path)
+		}
+
+		f.UI.Println(color.GreenString("Dev release %s (%s)%s", color.YellowString(release.Name), color.MagentaString(release.Version), releasePath))
 
 		for _, pkg := range release.Packages {
 			var isCached string
 
 			if verbose {
 				if _, err := os.Stat(pkg.Path); err == nil {
-					isCached = color.WhiteString(fmt.Sprintf(" (cached at %s)", pkg.Path))
+					isCached = color.WhiteString(" (cached at %s)", pkg.Path)
 				} else {
 					isCached = color.RedString(" (cache not found)")
 				}

--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -74,7 +74,7 @@ func TestListJobs(t *testing.T) {
 
 	err = f.LoadReleases([]string{releasePath}, []string{""}, []string{""}, releasePathCacheDir)
 	if assert.NoError(err) {
-		err = f.ListJobs()
+		err = f.ListJobs(false)
 		assert.Nil(err, "Expected ListJobs to find the release")
 	}
 }

--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -50,7 +50,7 @@ func TestListPackages(t *testing.T) {
 
 	err = f.LoadReleases([]string{releasePath}, []string{""}, []string{""}, releasePathCacheDir)
 	if assert.NoError(err) {
-		err = f.ListPackages()
+		err = f.ListPackages(false)
 		assert.Nil(err, "Expected ListPackages to find the release")
 	}
 }

--- a/cmd/build-packages.go
+++ b/cmd/build-packages.go
@@ -50,6 +50,7 @@ compiled once.
 			strings.FieldsFunc(flagBuildPackagesRoles, func(r rune) bool { return r == ',' }),
 			flagWorkers,
 			flagBuildPackagesWithoutDocker,
+			flagVerbose,
 		)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,6 +31,7 @@ var (
 	flagDarkOpinions       string
 	flagOutputFormat       string
 	flagMetrics            string
+	flagVerbose            bool
 
 	// workPath* variables contain paths derived from flagWorkDir
 	workPathCompilationDir string
@@ -181,6 +182,13 @@ func init() {
 		"Choose output format, one of human, json, or yaml (currently only for 'show properties')",
 	)
 
+	RootCmd.PersistentFlags().BoolP(
+		"verbose",
+		"V",
+		false,
+		"Enable verbose output.",
+	)
+
 	viper.BindPFlags(RootCmd.PersistentFlags())
 }
 
@@ -253,6 +261,7 @@ func validateBasicFlags() error {
 	flagDarkOpinions = viper.GetString("dark-opinions")
 	flagOutputFormat = viper.GetString("output")
 	flagMetrics = viper.GetString("metrics")
+	flagVerbose = viper.GetBool("verbose")
 
 	extendPathsFromWorkDirectory()
 

--- a/cmd/show-release.go
+++ b/cmd/show-release.go
@@ -25,7 +25,7 @@ The report contains the name, version, description and counts of jobs and packag
 			return err
 		}
 
-		if err := fissile.ListJobs(); err != nil {
+		if err := fissile.ListJobs(flagVerbose); err != nil {
 			return err
 		}
 

--- a/cmd/show-release.go
+++ b/cmd/show-release.go
@@ -29,7 +29,7 @@ The report contains the name, version, description and counts of jobs and packag
 			return err
 		}
 
-		return fissile.ListPackages()
+		return fissile.ListPackages(flagVerbose)
 	},
 }
 

--- a/compilator/compilator_linux_test.go
+++ b/compilator/compilator_linux_test.go
@@ -59,6 +59,6 @@ func TestCompilePackageInMountNS(t *testing.T) {
 	c, err := NewMountNSCompilator(tempDir, "", "repo", "linux", "0", ui)
 	assert.NoError(err)
 
-	err = c.Compile(2, []*model.Release{release}, nil)
+	err = c.Compile(2, []*model.Release{release}, nil, false)
 	assert.NoError(err, stderr.String())
 }

--- a/compilator/compilator_test.go
+++ b/compilator/compilator_test.go
@@ -53,7 +53,7 @@ func TestCompilationEmpty(t *testing.T) {
 
 	waitCh := make(chan struct{})
 	go func() {
-		err := c.Compile(1, genTestCase(), nil)
+		err := c.Compile(1, genTestCase(), nil, false)
 		close(waitCh)
 		assert.NoError(err)
 	}()
@@ -83,7 +83,7 @@ func TestCompilationBasic(t *testing.T) {
 
 	waitCh := make(chan struct{})
 	go func() {
-		c.Compile(1, release, nil)
+		c.Compile(1, release, nil, false)
 		close(waitCh)
 	}()
 
@@ -162,7 +162,7 @@ func TestCompilationSkipCompiled(t *testing.T) {
 
 	waitCh := make(chan struct{})
 	go func() {
-		c.Compile(1, release, nil)
+		c.Compile(1, release, nil, false)
 		close(waitCh)
 	}()
 
@@ -203,7 +203,7 @@ func TestCompilationRoleManifest(t *testing.T) {
 	waitCh := make(chan struct{})
 	errCh := make(chan error)
 	go func() {
-		errCh <- c.Compile(1, []*model.Release{release}, roleManifest.Roles)
+		errCh <- c.Compile(1, []*model.Release{release}, roleManifest.Roles, false)
 	}()
 	go func() {
 		// `libevent` is a dependency of `tor` and will be compiled first
@@ -365,7 +365,7 @@ func TestCompilationMultipleErrors(t *testing.T) {
 
 	release := genTestCase("ruby-2.5", "consul>go-1.4", "go-1.4")
 
-	err = c.Compile(1, release, nil)
+	err = c.Compile(1, release, nil, false)
 	assert.NotNil(err)
 }
 
@@ -468,7 +468,7 @@ func TestCompilationParallel(t *testing.T) {
 
 	testDoneCh := make(chan struct{})
 	go func() {
-		err = c.Compile(2, releases, nil)
+		err = c.Compile(2, releases, nil, false)
 		assert.NoError(err)
 		close(testDoneCh)
 	}()
@@ -720,7 +720,7 @@ func TestRemoveCompiledPackages(t *testing.T) {
 
 	releases := genTestCase("ruby-2.5", "consul>go-1.4", "go-1.4")
 
-	packages, err := c.removeCompiledPackages(c.gatherPackages(releases, nil))
+	packages, err := c.removeCompiledPackages(c.gatherPackages(releases, nil), false)
 	assert.NoError(err)
 
 	assert.Len(packages, 2)


### PR DESCRIPTION
Adds a verbose option to the `fissile show release` and `fissile build packages`
commands to show details about caching.