### PR TITLE
build images: allow manual --stemcell-id override

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -439,7 +439,9 @@ func (f *Fissile) GeneratePackagesRoleTarball(repository string, roleManifest *m
 	}
 	tarWriter := tar.NewWriter(tarFile)
 
-	tarPopulator := packagesImageBuilder.NewDockerPopulator(roles, force)
+	// We always force build all packages here to avoid needing to talk to the
+	// docker daemon to figure out what we can keep
+	tarPopulator := packagesImageBuilder.NewDockerPopulator(roles, true)
 	err = tarPopulator(tarWriter)
 	if err != nil {
 		return fmt.Errorf("Error writing tar file: %s", err)
@@ -454,7 +456,7 @@ func (f *Fissile) GeneratePackagesRoleTarball(repository string, roleManifest *m
 }
 
 // GenerateRoleImages generates all role images using dev releases
-func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, repository, stemcellImageName, metricsPath string, noBuild, force bool, roleNames []string, workerCount int, rolesManifestPath, compiledPackagesPath, lightManifestPath, darkManifestPath, outputDirectory string) error {
+func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, repository, stemcellImageName, stemcellImageID, metricsPath string, noBuild, force bool, roleNames []string, workerCount int, rolesManifestPath, compiledPackagesPath, lightManifestPath, darkManifestPath, outputDirectory string) error {
 	if len(f.releases) == 0 {
 		return fmt.Errorf("Releases not loaded")
 	}
@@ -492,6 +494,7 @@ func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, reposit
 	packagesImageBuilder, err := builder.NewPackagesImageBuilder(
 		repository,
 		stemcellImageName,
+		stemcellImageID,
 		compiledPackagesPath,
 		targetPath,
 		f.Version,

--- a/builder/packages_image_test.go
+++ b/builder/packages_image_test.go
@@ -65,7 +65,7 @@ func TestGenerateDockerfile(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(targetPath)
 
-	packagesImageBuilder, err := NewPackagesImageBuilder("foo", dockerImageName, compiledPackagesDir, targetPath, "3.14.15", ui)
+	packagesImageBuilder, err := NewPackagesImageBuilder("foo", dockerImageName, "", compiledPackagesDir, targetPath, "3.14.15", ui)
 	assert.NoError(err)
 
 	dockerfile := bytes.Buffer{}
@@ -111,7 +111,7 @@ func TestNewDockerPopulator(t *testing.T) {
 	rolesManifest, err := model.LoadRoleManifest(roleManifestPath, []*model.Release{release})
 	assert.NoError(err)
 
-	packagesImageBuilder, err := NewPackagesImageBuilder("foo", dockerImageName, compiledPackagesDir, targetPath, "3.14.15", ui)
+	packagesImageBuilder, err := NewPackagesImageBuilder("foo", dockerImageName, "", compiledPackagesDir, targetPath, "3.14.15", ui)
 	assert.NoError(err)
 
 	tarFile := &bytes.Buffer{}

--- a/cmd/build-images.go
+++ b/cmd/build-images.go
@@ -14,7 +14,8 @@ var (
 	flagPatchPropertiesDirective string
 	flagOutputDirectory          string
 
-	flagBuildImagesStemcell string
+	flagBuildImagesStemcell   string
+	flagBuildImagesStemcellID string
 )
 
 // buildImagesCmd represents the images command
@@ -50,6 +51,7 @@ from other specs.  At most one is allowed.  Its syntax is --patch-properties-rel
 		flagPatchPropertiesDirective = buildImagesViper.GetString("patch-properties-release")
 		flagOutputDirectory = buildImagesViper.GetString("output-directory")
 		flagBuildImagesStemcell = buildImagesViper.GetString("stemcell")
+		flagBuildImagesStemcellID = buildImagesViper.GetString("stemcell-id")
 
 		err := fissile.LoadReleases(
 			flagRelease,
@@ -72,6 +74,7 @@ from other specs.  At most one is allowed.  Its syntax is --patch-properties-rel
 			flagDockerOrganization,
 			flagRepository,
 			flagBuildImagesStemcell,
+			flagBuildImagesStemcellID,
 			flagMetrics,
 			flagBuildImagesNoBuild,
 			flagBuildImagesForce,
@@ -133,6 +136,13 @@ func init() {
 		"s",
 		"",
 		"The source stemcell",
+	)
+
+	buildImagesCmd.PersistentFlags().StringP(
+		"stemcell-id",
+		"",
+		"",
+		"Docker image ID for the stemcell (intended for CI)",
 	)
 
 	buildImagesViper.BindPFlags(buildImagesCmd.PersistentFlags())


### PR DESCRIPTION
This makes it possible to build images without having docker running, which is required for CI.  If the stemcell ID is not given (the normal case), fissile will still ask docker for it.