### PR TITLE
compilation: add option to only build packages from a subset of releases

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -244,7 +244,7 @@ func newPropertyInfo(maybeHash bool) *propertyInfo {
 }
 
 // Compile will compile a list of dev BOSH releases
-func (f *Fissile) Compile(stemcellImageName string, targetPath, roleManifestPath, metricsPath string, roleNames []string, workerCount int, withoutDocker, verbose bool) error {
+func (f *Fissile) Compile(stemcellImageName string, targetPath, roleManifestPath, metricsPath string, roleNames, releaseNames []string, workerCount int, withoutDocker, verbose bool) error {
 	if len(f.releases) == 0 {
 		return fmt.Errorf("Releases not loaded")
 	}
@@ -287,7 +287,12 @@ func (f *Fissile) Compile(stemcellImageName string, targetPath, roleManifestPath
 		return fmt.Errorf("Error selecting packages to build: %s", err.Error())
 	}
 
-	if err := comp.Compile(workerCount, f.releases, roles, verbose); err != nil {
+	releases, err := f.getReleasesByName(releaseNames)
+	if err != nil {
+		return err
+	}
+
+	if err := comp.Compile(workerCount, releases, roles, verbose); err != nil {
 		return fmt.Errorf("Error compiling packages: %s", err.Error())
 	}
 
@@ -635,6 +640,31 @@ func (f *Fissile) LoadReleases(releasePaths, releaseNames, releaseVersions []str
 	f.releases = releases
 
 	return nil
+}
+
+// getReleasesByName returns all named releases, or all releases if no names are given
+func (f *Fissile) getReleasesByName(releaseNames []string) ([]*model.Release, error) {
+	if len(releaseNames) == 0 {
+		return f.releases, nil
+	}
+
+	var releases []*model.Release
+	var missingReleases []string
+releaseNameLoop:
+	for _, releaseName := range releaseNames {
+		for _, release := range f.releases {
+			if release.Name == releaseName {
+				releases = append(releases, release)
+				continue releaseNameLoop
+			}
+		}
+		missingReleases = append(missingReleases, releaseName)
+	}
+	if len(missingReleases) > 0 {
+		return nil, fmt.Errorf("Some releases are unknown: %v", missingReleases)
+	}
+	return releases, nil
+
 }
 
 // DiffConfigurationBases generates a diff comparing the specs for two different BOSH releases

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -264,8 +264,13 @@ func (f *Fissile) Compile(stemcellImageName string, targetPath, roleManifestPath
 		return fmt.Errorf("Error loading roles manifest: %s", err.Error())
 	}
 
+	releases, err := f.getReleasesByName(releaseNames)
+	if err != nil {
+		return err
+	}
+
 	f.UI.Println(color.GreenString("Compiling packages for dev releases:"))
-	for _, release := range f.releases {
+	for _, release := range releases {
 		f.UI.Printf("         %s (%s)\n", color.YellowString(release.Name), color.MagentaString(release.Version))
 	}
 
@@ -285,11 +290,6 @@ func (f *Fissile) Compile(stemcellImageName string, targetPath, roleManifestPath
 	roles, err := roleManifest.SelectRoles(roleNames)
 	if err != nil {
 		return fmt.Errorf("Error selecting packages to build: %s", err.Error())
-	}
-
-	releases, err := f.getReleasesByName(releaseNames)
-	if err != nil {
-		return err
 	}
 
 	if err := comp.Compile(workerCount, releases, roles, verbose); err != nil {

--- a/cmd/build-packages.go
+++ b/cmd/build-packages.go
@@ -29,6 +29,7 @@ compiled once.
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		flagBuildPackagesRoles := buildPackagesViper.GetString("roles")
+		flagBuildPackagesOnlyReleases := buildPackagesViper.GetString("only-releases")
 		flagBuildPackagesWithoutDocker := buildPackagesViper.GetBool("without-docker")
 		flagBuildPackagesStemcell := buildPackagesViper.GetString("stemcell")
 
@@ -48,6 +49,7 @@ compiled once.
 			flagRoleManifest,
 			flagMetrics,
 			strings.FieldsFunc(flagBuildPackagesRoles, func(r rune) bool { return r == ',' }),
+			strings.FieldsFunc(flagBuildPackagesOnlyReleases, func(r rune) bool { return r == ',' }),
 			flagWorkers,
 			flagBuildPackagesWithoutDocker,
 			flagVerbose,
@@ -68,6 +70,13 @@ func init() {
 		"",
 		"",
 		"Build only packages for the given role names; comma separated.",
+	)
+
+	buildPackagesCmd.PersistentFlags().StringP(
+		"only-releases",
+		"",
+		"",
+		"Build only packages for the given release names; comma separated.",
 	)
 
 	buildPackagesCmd.PersistentFlags().BoolP(


### PR DESCRIPTION
This adds a `--only-releases` option to `fissile build packages` such that it will not attempt to build packages not in the listed releases.

We wanted this for CI (so we can build all packages for a release, then throw them at the image builder)