### PR TITLE
Test for existence of cron tabs dir before chown

### DIFF
--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -94,7 +94,7 @@ chmod 775 /var/vcap/sys/run
 
 # Fix permissions
 chmod 640 /var/log/messages
-if [ -e /var/spool/cron/tabs ]
+if [ -d /var/spool/cron/tabs ]
 then
   chmod 1730 /var/spool/cron/tabs/
 fi

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -94,7 +94,10 @@ chmod 775 /var/vcap/sys/run
 
 # Fix permissions
 chmod 640 /var/log/messages
-chmod 1730 /var/spool/cron/tabs/
+if [ -e /var/spool/cron/tabs ]
+then
+  chmod 1730 /var/spool/cron/tabs/
+fi
 
 {{ if eq .role.Type "bosh-task" }}
     # Start rsyslog and cron


### PR DESCRIPTION
Fixes https://github.com/SUSE/fissile/issues/254.

`/var/spool/cron/tabs/` is SUSE specific.