### PR TITLE
kube: change the statefulset headless service suffix to -set

### DIFF
--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -52,7 +52,7 @@ All roles without the above constraints will be generated as deployments.
 Each role may have attached services generated as necessary.  There are three
 general conditions:
 
-- Each StatefulSet will have a headless service (e.g. `nats-pod`); this is used
+- Each StatefulSet will have a headless service (e.g. `nats-set`); this is used
   to manage the StatefulSet (a Kubernetes requirement), and to allow discovery
   of pods within a role via DNS.
 - A role may have a service for its public ports, if any port is public.

--- a/kube/service.go
+++ b/kube/service.go
@@ -71,7 +71,7 @@ func NewClusterIPService(role *model.Role, headless bool, public bool) (*apiv1.S
 		},
 	}
 	if headless {
-		service.ObjectMeta.Name = fmt.Sprintf("%s-pod", role.Name)
+		service.ObjectMeta.Name = fmt.Sprintf("%s-set", role.Name)
 		service.Spec.ClusterIP = apiv1.ClusterIPNone
 	} else if public {
 		service.ObjectMeta.Name = fmt.Sprintf("%s-public", role.Name)

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -128,7 +128,7 @@ func TestHeadlessServiceOK(t *testing.T) {
 	}
 	expectedYAML := strings.Replace(`---
 			metadata:
-				name: myrole-pod
+				name: myrole-set
 			spec:
 				ports:
 				-

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -44,7 +44,7 @@ func NewStatefulSet(role *model.Role, settings *ExportSettings) (*v1beta1.Statef
 		},
 		Spec: v1beta1.StatefulSetSpec{
 			Replicas:             &role.Run.Scaling.Min,
-			ServiceName:          fmt.Sprintf("%s-pod", role.Name),
+			ServiceName:          fmt.Sprintf("%s-set", role.Name),
 			Template:             podTemplate,
 			VolumeClaimTemplates: volumeClaimTemplates,
 		},

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -119,7 +119,7 @@ func TestStatefulSetPorts(t *testing.T) {
 		assert.Equal(role.Name+"-public", endpointService.ObjectMeta.Name, "unexpected endpoint service name")
 	}
 	if assert.NotNil(headlessService, "headless service not found") {
-		assert.Equal(role.Name+"-pod", headlessService.ObjectMeta.Name, "unexpected headless service name")
+		assert.Equal(role.Name+"-set", headlessService.ObjectMeta.Name, "unexpected headless service name")
 	}
 
 	objects := apiv1.List{
@@ -141,7 +141,7 @@ func TestStatefulSetPorts(t *testing.T) {
 		-
 			# This is the per-pod naming port
 			metadata:
-				name: myrole-pod
+				name: myrole-set
 			spec:
 				ports:
 				-
@@ -194,7 +194,7 @@ func TestStatefulSetPorts(t *testing.T) {
 				name: myrole
 			spec:
 				replicas: 1
-				serviceName: myrole-pod
+				serviceName: myrole-set
 				template:
 					metadata:
 						labels:
@@ -248,7 +248,7 @@ func TestStatefulSetVolumes(t *testing.T) {
 		name: myrole
 	spec:
 		replicas: 1
-		serviceName: myrole-pod
+		serviceName: myrole-set
 		template:
 			metadata:
 				labels:


### PR DESCRIPTION
Vlad liked it better than `-pod`.