### PR TITLE
Fix package layer signature calculation

### DIFF
--- a/builder/packages_image_test.go
+++ b/builder/packages_image_test.go
@@ -14,8 +14,11 @@ import (
 
 	"github.com/SUSE/fissile/docker"
 	"github.com/SUSE/fissile/model"
+
 	"github.com/SUSE/termui"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	yaml "gopkg.in/yaml.v2"
 )
 
 const (
@@ -188,4 +191,134 @@ func TestNewDockerPopulator(t *testing.T) {
 		}
 	}
 	assert.Empty(testFunctions, "Missing files in tar stream")
+}
+
+func setHash(hash map[string]interface{}, value interface{}, keys ...string) {
+	var child map[interface{}]interface{}
+	for i, k := range keys {
+		if i >= len(keys)-1 {
+			// don't get the last one
+			break
+		}
+		if i == 0 {
+			child = hash[k].(map[interface{}]interface{})
+		} else {
+			child = child[k].(map[interface{}]interface{})
+		}
+	}
+	child[keys[len(keys)-1]] = value
+}
+
+func TestGetRolePackageImageName(t *testing.T) {
+	workDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	releasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	releasePathCache := filepath.Join(releasePath, "bosh-cache")
+
+	release, err := model.NewDevRelease(releasePath, "", "", releasePathCache)
+	assert.NoError(t, err)
+
+	roleManifestDir := filepath.Join(workDir, "../test-assets/role-manifests/")
+	roleManifestPath := filepath.Join(roleManifestDir, "tor-good.yml")
+	roleManifest, err := model.LoadRoleManifest(roleManifestPath, []*model.Release{release})
+	assert.NoError(t, err)
+
+	t.Run("FissileVersionShouldBeRelevant", func(t *testing.T) {
+		builder := PackagesImageBuilder{
+			repository:      "test",
+			fissileVersion:  "0.1.2",
+			stemcellImageID: "stemcell:latest",
+		}
+
+		oldImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		assert.NoError(t, err)
+
+		builder.fissileVersion += ".4.5.6"
+		newImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		assert.NoError(t, err)
+
+		assert.NotEqual(t, oldImageName, newImageName, "Changing fissile version should change package layer hash")
+	})
+
+	t.Run("StemcellImageIDShouldBeRelevant", func(t *testing.T) {
+		builder := PackagesImageBuilder{
+			repository:      "test",
+			fissileVersion:  "0.1.2",
+			stemcellImageID: "stemcell:latest",
+		}
+
+		oldImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		assert.NoError(t, err)
+
+		builder.stemcellImageID = "stemcell:newer"
+		newImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		assert.NoError(t, err)
+
+		assert.NotEqual(t, oldImageName, newImageName, "Changing stemcell image ID should change package layer hash")
+	})
+
+	t.Run("RepositoryShouldBeRelevant", func(t *testing.T) {
+		builder := PackagesImageBuilder{
+			repository:      "test",
+			fissileVersion:  "0.1.2",
+			stemcellImageID: "stemcell:latest",
+		}
+		oldImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		assert.NoError(t, err)
+
+		builder.repository = "repository"
+		newImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		assert.NoError(t, err)
+
+		assert.NotEqual(t, oldImageName, newImageName, "Changing repository should change package layer hash")
+	})
+
+	t.Run("TemplatesShouldBeIrrelevant", func(t *testing.T) {
+		builder := PackagesImageBuilder{
+			repository:      "test",
+			fissileVersion:  "0.1.2",
+			stemcellImageID: "stemcell:latest",
+		}
+
+		oldImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		assert.NoError(t, err)
+
+		yamlRaw, err := ioutil.ReadFile(roleManifestPath)
+		require.NoError(t, err, "Error reading role manifest")
+
+		var yamlContents map[string]interface{}
+		err = yaml.Unmarshal(yamlRaw, &yamlContents)
+		require.NoError(t, err)
+		setHash(yamlContents, "((#FOO))((/FOO))((BAR))", "configuration", "templates", "properties.tor.hostname")
+		yamlBytes, err := yaml.Marshal(yamlContents)
+		require.NoError(t, err, "Failed to marshal edited YAML")
+
+		tempManifestFile, err := ioutil.TempFile(roleManifestDir, "fissile-test-role-manifest-")
+		require.NoError(t, err, "Error creating temporary file")
+		defer os.Remove(tempManifestFile.Name())
+		assert.NoError(t, tempManifestFile.Close(), "Error closing temporary file")
+		assert.NoError(t, ioutil.WriteFile(tempManifestFile.Name(), yamlBytes, 0644), "Error writing modified role manifest")
+		modifiedRoleManifest, err := model.LoadRoleManifest(tempManifestFile.Name(), []*model.Release{release})
+		assert.NoError(t, err, "Error loading modified role manifest")
+
+		newImageName, err := builder.GetRolePackageImageName(modifiedRoleManifest, modifiedRoleManifest.Roles)
+		assert.NoError(t, err)
+		assert.Equal(t, oldImageName, newImageName, "Changing templates should not change image hash")
+	})
+
+	t.Run("RolesShouldBeRelevant", func(t *testing.T) {
+		builder := PackagesImageBuilder{
+			repository:      "test",
+			fissileVersion:  "0.1.2",
+			stemcellImageID: "stemcell:latest",
+		}
+		oldImageName, err := builder.GetRolePackageImageName(roleManifest, nil)
+		assert.NoError(t, err)
+
+		newImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		assert.NoError(t, err)
+
+		assert.NotEqual(t, oldImageName, newImageName, "Changing roles should change package layer hash")
+	})
 }


### PR DESCRIPTION
The package layer tag was accidentally including the template information. This is causing unnecessary rebuilds.