### PR TITLE
builder: rename PackagesImageBuilder.GetRolePackageImageName()

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -424,7 +424,7 @@ func (f *Fissile) GeneratePackagesRoleImage(stemcellImageName string, roleManife
 		return fmt.Errorf("Error connecting to docker: %s", err.Error())
 	}
 
-	packagesLayerImageName, err := packagesImageBuilder.GetRolePackageImageName(roleManifest, roles)
+	packagesLayerImageName, err := packagesImageBuilder.GetPackagesLayerImageName(roleManifest, roles)
 	if err != nil {
 		return fmt.Errorf("Error finding role's package name: %s", err.Error())
 	}
@@ -472,7 +472,7 @@ func (f *Fissile) GeneratePackagesRoleTarball(repository string, roleManifest *m
 		return fmt.Errorf("Releases not loaded")
 	}
 
-	packagesLayerImageName, err := packagesImageBuilder.GetRolePackageImageName(roleManifest, roles)
+	packagesLayerImageName, err := packagesImageBuilder.GetPackagesLayerImageName(roleManifest, roles)
 	if err != nil {
 		return fmt.Errorf("Error finding role's package name: %v", err)
 	}
@@ -578,7 +578,7 @@ func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, reposit
 		return err
 	}
 
-	packagesLayerImageName, err := packagesImageBuilder.GetRolePackageImageName(roleManifest, roles)
+	packagesLayerImageName, err := packagesImageBuilder.GetPackagesLayerImageName(roleManifest, roles)
 	if err != nil {
 		return err
 	}

--- a/builder/packages_image.go
+++ b/builder/packages_image.go
@@ -261,8 +261,8 @@ func (p *PackagesImageBuilder) generateDockerfile(baseImage string, packages mod
 	return nil
 }
 
-// GetRolePackageImageName generates a docker image name for the amalgamation for a role image
-func (p *PackagesImageBuilder) GetRolePackageImageName(roleManifest *model.RoleManifest, roles model.Roles) (string, error) {
+// GetPackagesLayerImageName generates a docker image name for the amalgamation holding all packages used in the specified roles
+func (p *PackagesImageBuilder) GetPackagesLayerImageName(roleManifest *model.RoleManifest, roles model.Roles) (string, error) {
 	// Get the list of packages; use the fingerprint to ensure we have no repeats
 	pkgMap := make(map[string]*model.Package)
 	for _, r := range roles {

--- a/builder/packages_image_test.go
+++ b/builder/packages_image_test.go
@@ -232,11 +232,11 @@ func TestGetRolePackageImageName(t *testing.T) {
 			stemcellImageID: "stemcell:latest",
 		}
 
-		oldImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		oldImageName, err := builder.GetPackagesLayerImageName(roleManifest, roleManifest.Roles)
 		assert.NoError(t, err)
 
 		builder.fissileVersion += ".4.5.6"
-		newImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		newImageName, err := builder.GetPackagesLayerImageName(roleManifest, roleManifest.Roles)
 		assert.NoError(t, err)
 
 		assert.NotEqual(t, oldImageName, newImageName, "Changing fissile version should change package layer hash")
@@ -250,11 +250,11 @@ func TestGetRolePackageImageName(t *testing.T) {
 			stemcellImageID: "stemcell:latest",
 		}
 
-		oldImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		oldImageName, err := builder.GetPackagesLayerImageName(roleManifest, roleManifest.Roles)
 		assert.NoError(t, err)
 
 		builder.stemcellImageID = "stemcell:newer"
-		newImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		newImageName, err := builder.GetPackagesLayerImageName(roleManifest, roleManifest.Roles)
 		assert.NoError(t, err)
 
 		assert.NotEqual(t, oldImageName, newImageName, "Changing stemcell image ID should change package layer hash")
@@ -269,11 +269,11 @@ func TestGetRolePackageImageName(t *testing.T) {
 			fissileVersion:  "0.1.2",
 			stemcellImageID: "stemcell:latest",
 		}
-		oldImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		oldImageName, err := builder.GetPackagesLayerImageName(roleManifest, roleManifest.Roles)
 		assert.NoError(t, err)
 
 		builder.repository = "repository"
-		newImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		newImageName, err := builder.GetPackagesLayerImageName(roleManifest, roleManifest.Roles)
 		assert.NoError(t, err)
 
 		assert.NotEqual(t, oldImageName, newImageName, "Changing repository should change package layer hash")
@@ -291,7 +291,7 @@ func TestGetRolePackageImageName(t *testing.T) {
 			stemcellImageID: "stemcell:latest",
 		}
 
-		oldImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		oldImageName, err := builder.GetPackagesLayerImageName(roleManifest, roleManifest.Roles)
 		assert.NoError(t, err)
 
 		yamlRaw, err := ioutil.ReadFile(roleManifestPath)
@@ -312,7 +312,7 @@ func TestGetRolePackageImageName(t *testing.T) {
 		modifiedRoleManifest, err := model.LoadRoleManifest(tempManifestFile.Name(), []*model.Release{release})
 		assert.NoError(t, err, "Error loading modified role manifest")
 
-		newImageName, err := builder.GetRolePackageImageName(modifiedRoleManifest, modifiedRoleManifest.Roles)
+		newImageName, err := builder.GetPackagesLayerImageName(modifiedRoleManifest, modifiedRoleManifest.Roles)
 		assert.NoError(t, err)
 		assert.Equal(t, oldImageName, newImageName, "Changing templates should not change image hash")
 	})
@@ -324,10 +324,10 @@ func TestGetRolePackageImageName(t *testing.T) {
 			fissileVersion:  "0.1.2",
 			stemcellImageID: "stemcell:latest",
 		}
-		oldImageName, err := builder.GetRolePackageImageName(roleManifest, nil)
+		oldImageName, err := builder.GetPackagesLayerImageName(roleManifest, nil)
 		assert.NoError(t, err)
 
-		newImageName, err := builder.GetRolePackageImageName(roleManifest, roleManifest.Roles)
+		newImageName, err := builder.GetPackagesLayerImageName(roleManifest, roleManifest.Roles)
 		assert.NoError(t, err)
 
 		assert.NotEqual(t, oldImageName, newImageName, "Changing roles should change package layer hash")
@@ -363,11 +363,11 @@ func TestGetRolePackageImageName(t *testing.T) {
 			stemcellImageID: "stemcell:latest",
 		}
 		role := makeTemplateRole()
-		oldImageName, err := builder.GetRolePackageImageName(roleManifest, model.Roles{role})
+		oldImageName, err := builder.GetPackagesLayerImageName(roleManifest, model.Roles{role})
 		assert.NoError(t, err)
 
 		role.Jobs[0].Packages[0].SHA1 = "different sha1"
-		newImageName, err := builder.GetRolePackageImageName(roleManifest, model.Roles{role})
+		newImageName, err := builder.GetPackagesLayerImageName(roleManifest, model.Roles{role})
 		assert.NoError(t, err)
 
 		assert.NotEqual(t, oldImageName, newImageName, "Changing package SHA1 should change package layer hash")
@@ -381,11 +381,11 @@ func TestGetRolePackageImageName(t *testing.T) {
 			stemcellImageID: "stemcell:latest",
 		}
 		role := makeTemplateRole()
-		oldImageName, err := builder.GetRolePackageImageName(roleManifest, model.Roles{role})
+		oldImageName, err := builder.GetPackagesLayerImageName(roleManifest, model.Roles{role})
 		assert.NoError(t, err)
 
 		role.Jobs[0].Packages[0].Fingerprint = "different fingerprint"
-		newImageName, err := builder.GetRolePackageImageName(roleManifest, model.Roles{role})
+		newImageName, err := builder.GetPackagesLayerImageName(roleManifest, model.Roles{role})
 		assert.NoError(t, err)
 
 		assert.NotEqual(t, oldImageName, newImageName, "Changing package fingerprint should change package layer hash")
@@ -399,11 +399,11 @@ func TestGetRolePackageImageName(t *testing.T) {
 			stemcellImageID: "stemcell:latest",
 		}
 		role := makeTemplateRole()
-		oldImageName, err := builder.GetRolePackageImageName(roleManifest, model.Roles{role})
+		oldImageName, err := builder.GetPackagesLayerImageName(roleManifest, model.Roles{role})
 		assert.NoError(t, err)
 
 		role.Jobs[0].Packages[0].Name = "different name"
-		newImageName, err := builder.GetRolePackageImageName(roleManifest, model.Roles{role})
+		newImageName, err := builder.GetPackagesLayerImageName(roleManifest, model.Roles{role})
 		assert.NoError(t, err)
 
 		assert.NotEqual(t, oldImageName, newImageName, "Changing package name should change package layer hash")


### PR DESCRIPTION
Naming it GetPackagesLayerImageName() should hopefully be less confusing