### PR TITLE
Add additional logging level

### DIFF
--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/SUSE/fissile/model"
+	"github.com/SUSE/fissile/util"
 
 	"github.com/SUSE/termui"
 	"github.com/stretchr/testify/assert"
@@ -53,7 +54,7 @@ func TestListPackages(t *testing.T) {
 
 	err = f.LoadReleases([]string{releasePath}, []string{""}, []string{""}, releasePathCacheDir)
 	if assert.NoError(err) {
-		err = f.ListPackages(false)
+		err = f.ListPackages(util.VerbosityDefault)
 		assert.Nil(err, "Expected ListPackages to find the release")
 	}
 }
@@ -77,7 +78,7 @@ func TestListJobs(t *testing.T) {
 
 	err = f.LoadReleases([]string{releasePath}, []string{""}, []string{""}, releasePathCacheDir)
 	if assert.NoError(err) {
-		err = f.ListJobs(false)
+		err = f.ListJobs(util.VerbosityDefault)
 		assert.Nil(err, "Expected ListJobs to find the release")
 	}
 }

--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -339,6 +339,7 @@ type roleBuildJob struct {
 	organization    string
 	repository      string
 	baseImageName   string
+	verbosity       util.Verbosity
 }
 
 func (j roleBuildJob) Run() {
@@ -355,7 +356,7 @@ func (j roleBuildJob) Run() {
 			return err
 		}
 
-		devVersion, err := j.role.GetRoleDevVersion(opinions, j.builder.fissileVersion)
+		devVersion, err := j.role.GetRoleDevVersion(opinions, j.builder.fissileVersion, j.verbosity)
 		if err != nil {
 			return err
 		}
@@ -438,7 +439,7 @@ func (j roleBuildJob) Run() {
 }
 
 // BuildRoleImages triggers the building of the role docker images in parallel
-func (r *RoleImageBuilder) BuildRoleImages(roles model.Roles, registry, organization, repository, baseImageName, outputDirectory string, force, noBuild bool, workerCount int) error {
+func (r *RoleImageBuilder) BuildRoleImages(roles model.Roles, registry, organization, repository, baseImageName, outputDirectory string, force, noBuild bool, workerCount int, verbosity util.Verbosity) error {
 	if workerCount < 1 {
 		return fmt.Errorf("Invalid worker count %d", workerCount)
 	}
@@ -474,6 +475,7 @@ func (r *RoleImageBuilder) BuildRoleImages(roles model.Roles, registry, organiza
 			organization:    organization,
 			repository:      repository,
 			baseImageName:   baseImageName,
+			verbosity:       verbosity,
 		})
 	}
 

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/SUSE/fissile/model"
+	"github.com/SUSE/fissile/util"
 	"github.com/SUSE/termui"
 
 	"github.com/stretchr/testify/assert"
@@ -460,6 +461,7 @@ func TestBuildRoleImages(t *testing.T) {
 		false,
 		false,
 		2,
+		util.VerbosityDefault,
 	)
 	assert.NoError(err)
 
@@ -482,6 +484,7 @@ func TestBuildRoleImages(t *testing.T) {
 		false,
 		false,
 		0,
+		util.VerbosityDefault,
 	)
 	assert.Error(err, "Invalid worker count should result in an error")
 	assert.Contains(err.Error(), "count", "Building the image should have failed due to invalid worker count")
@@ -510,6 +513,7 @@ func TestBuildRoleImages(t *testing.T) {
 		false,
 		false,
 		1,
+		util.VerbosityDefault,
 	)
 	if assert.Error(err) {
 		assert.Contains(err.Error(), "Deliberate failure", "Returned error should be from first job failing")
@@ -536,6 +540,7 @@ func TestBuildRoleImages(t *testing.T) {
 		false,
 		false,
 		len(rolesManifest.Roles),
+		util.VerbosityDefault,
 	)
 	assert.NoError(err)
 	assert.Empty(buildersRan, "should not have ran any builders")
@@ -570,6 +575,7 @@ func TestBuildRoleImages(t *testing.T) {
 		false,
 		false,
 		1,
+		util.VerbosityDefault,
 	)
 	assert.NoError(err)
 

--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -56,6 +56,7 @@ var buildHelmCmd = &cobra.Command{
 			true,
 			flagBuildHelmChartFilename,
 			opinions,
+			flagVerbose,
 		)
 	},
 }

--- a/cmd/build-images.go
+++ b/cmd/build-images.go
@@ -83,6 +83,7 @@ from other specs.  At most one is allowed.
 			flagLightOpinions,
 			flagDarkOpinions,
 			flagOutputDirectory,
+			flagVerbose,
 		)
 	},
 }

--- a/cmd/build-kube.go
+++ b/cmd/build-kube.go
@@ -54,6 +54,7 @@ var buildKubeCmd = &cobra.Command{
 			false,
 			"",
 			opinions,
+			flagVerbose,
 		)
 	},
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/viper"
 
 	"github.com/SUSE/fissile/app"
+	"github.com/SUSE/fissile/util"
 )
 
 var (
@@ -31,7 +32,7 @@ var (
 	flagDarkOpinions       string
 	flagOutputFormat       string
 	flagMetrics            string
-	flagVerbose            bool
+	flagVerbose            util.Verbosity
 
 	// workPath* variables contain paths derived from flagWorkDir
 	workPathCompilationDir string
@@ -182,11 +183,14 @@ func init() {
 		"Choose output format, one of human, json, or yaml (currently only for 'show properties')",
 	)
 
-	RootCmd.PersistentFlags().BoolP(
+	RootCmd.PersistentFlags().CountP(
 		"verbose",
 		"V",
-		false,
-		"Enable verbose output.",
+		"Output more messages.",
+	)
+	RootCmd.PersistentFlags().Count(
+		"quiet",
+		"Output fewer messages.",
 	)
 
 	viper.BindPFlags(RootCmd.PersistentFlags())
@@ -261,7 +265,7 @@ func validateBasicFlags() error {
 	flagDarkOpinions = viper.GetString("dark-opinions")
 	flagOutputFormat = viper.GetString("output")
 	flagMetrics = viper.GetString("metrics")
-	flagVerbose = viper.GetBool("verbose")
+	flagVerbose = util.VerbosityDebug + util.Verbosity(viper.GetInt("verbose")) - util.Verbosity(viper.GetInt("quiet"))
 
 	extendPathsFromWorkDirectory()
 

--- a/cmd/show-image.go
+++ b/cmd/show-image.go
@@ -44,6 +44,7 @@ This command is useful in conjunction with docker (e.g. ` + "`docker rmi $(fissi
 			flagDarkOpinions,
 			flagShowImageDockerOnly,
 			flagShowImageWithSizes,
+			flagVerbose,
 		)
 	},
 }

--- a/compilator/compilator_linux_test.go
+++ b/compilator/compilator_linux_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/SUSE/fissile/model"
+	"github.com/SUSE/fissile/util"
 	"github.com/SUSE/termui"
 	"github.com/stretchr/testify/assert"
 )
@@ -59,6 +60,6 @@ func TestCompilePackageInMountNS(t *testing.T) {
 	c, err := NewMountNSCompilator(tempDir, "", "repo", "linux", "0", ui)
 	assert.NoError(err)
 
-	err = c.Compile(2, []*model.Release{release}, nil, false)
+	err = c.Compile(2, []*model.Release{release}, nil, util.VerbosityDefault)
 	assert.NoError(err, stderr.String())
 }

--- a/compilator/compilator_test.go
+++ b/compilator/compilator_test.go
@@ -53,7 +53,7 @@ func TestCompilationEmpty(t *testing.T) {
 
 	waitCh := make(chan struct{})
 	go func() {
-		err := c.Compile(1, genTestCase(), nil, false)
+		err := c.Compile(1, genTestCase(), nil, util.VerbosityDefault)
 		close(waitCh)
 		assert.NoError(err)
 	}()
@@ -83,7 +83,7 @@ func TestCompilationBasic(t *testing.T) {
 
 	waitCh := make(chan struct{})
 	go func() {
-		c.Compile(1, release, nil, false)
+		c.Compile(1, release, nil, util.VerbosityDefault)
 		close(waitCh)
 	}()
 
@@ -162,7 +162,7 @@ func TestCompilationSkipCompiled(t *testing.T) {
 
 	waitCh := make(chan struct{})
 	go func() {
-		c.Compile(1, release, nil, false)
+		c.Compile(1, release, nil, util.VerbosityDefault)
 		close(waitCh)
 	}()
 
@@ -203,7 +203,7 @@ func TestCompilationRoleManifest(t *testing.T) {
 	waitCh := make(chan struct{})
 	errCh := make(chan error)
 	go func() {
-		errCh <- c.Compile(1, []*model.Release{release}, roleManifest.Roles, false)
+		errCh <- c.Compile(1, []*model.Release{release}, roleManifest.Roles, util.VerbosityDefault)
 	}()
 	go func() {
 		// `libevent` is a dependency of `tor` and will be compiled first
@@ -365,7 +365,7 @@ func TestCompilationMultipleErrors(t *testing.T) {
 
 	release := genTestCase("ruby-2.5", "consul>go-1.4", "go-1.4")
 
-	err = c.Compile(1, release, nil, false)
+	err = c.Compile(1, release, nil, util.VerbosityDefault)
 	assert.NotNil(err)
 }
 
@@ -468,7 +468,7 @@ func TestCompilationParallel(t *testing.T) {
 
 	testDoneCh := make(chan struct{})
 	go func() {
-		err = c.Compile(2, releases, nil, false)
+		err = c.Compile(2, releases, nil, util.VerbosityDefault)
 		assert.NoError(err)
 		close(testDoneCh)
 	}()
@@ -720,7 +720,7 @@ func TestRemoveCompiledPackages(t *testing.T) {
 
 	releases := genTestCase("ruby-2.5", "consul>go-1.4", "go-1.4")
 
-	packages, err := c.removeCompiledPackages(c.gatherPackages(releases, nil), false)
+	packages, err := c.removeCompiledPackages(c.gatherPackages(releases, nil), util.VerbosityDefault)
 	assert.NoError(err)
 
 	assert.Len(packages, 2)

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"github.com/SUSE/fissile/model"
+	"github.com/SUSE/fissile/util"
 
 	meta "k8s.io/client-go/pkg/api/unversioned"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
@@ -9,9 +10,9 @@ import (
 )
 
 // NewDeployment creates a Deployment for the given role, and its attached services
-func NewDeployment(role *model.Role, settings *ExportSettings) (*extra.Deployment, *apiv1.List, error) {
+func NewDeployment(role *model.Role, settings *ExportSettings, verbosity util.Verbosity) (*extra.Deployment, *apiv1.List, error) {
 
-	podTemplate, err := NewPodTemplate(role, settings)
+	podTemplate, err := NewPodTemplate(role, settings, verbosity)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kube/job.go
+++ b/kube/job.go
@@ -4,14 +4,15 @@ import (
 	"fmt"
 
 	"github.com/SUSE/fissile/model"
+	"github.com/SUSE/fissile/util"
 	meta "k8s.io/client-go/pkg/api/unversioned"
 	apiv1 "k8s.io/client-go/pkg/api/v1"
 	extra "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
 // NewJob creates a new Job for the given role, as well as any objects it depends on
-func NewJob(role *model.Role, settings *ExportSettings) (*extra.Job, error) {
-	podTemplate, err := NewPodTemplate(role, settings)
+func NewJob(role *model.Role, settings *ExportSettings, verbosity util.Verbosity) (*extra.Job, error) {
+	podTemplate, err := NewPodTemplate(role, settings, verbosity)
 	if err != nil {
 		return nil, err
 	}

--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/SUSE/fissile/model"
 	"github.com/SUSE/fissile/testhelpers"
+	"github.com/SUSE/fissile/util"
 
 	"github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v2"
@@ -48,7 +49,7 @@ func TestJobPreFlight(t *testing.T) {
 
 	job, err := NewJob(role, &ExportSettings{
 		Opinions: model.NewEmptyOpinions(),
-	})
+	}, util.VerbosityDefault)
 	if !assert.NoError(err, "Failed to create job from role pre-role") {
 		return
 	}
@@ -93,7 +94,7 @@ func TestJobPostFlight(t *testing.T) {
 
 	job, err := NewJob(role, &ExportSettings{
 		Opinions: model.NewEmptyOpinions(),
-	})
+	}, util.VerbosityDefault)
 	if !assert.NoError(err, "Failed to create job from role post-role") {
 		return
 	}

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/SUSE/fissile/builder"
 	"github.com/SUSE/fissile/model"
+	"github.com/SUSE/fissile/util"
 
 	"k8s.io/client-go/pkg/api/resource"
 	meta "k8s.io/client-go/pkg/api/unversioned"
@@ -22,7 +23,7 @@ const monitPort = 2289
 
 // NewPodTemplate creates a new pod template spec for a given role, as well as
 // any objects it depends on
-func NewPodTemplate(role *model.Role, settings *ExportSettings) (v1.PodTemplateSpec, error) {
+func NewPodTemplate(role *model.Role, settings *ExportSettings, verbosity util.Verbosity) (v1.PodTemplateSpec, error) {
 
 	vars, err := getEnvVars(role, settings.Defaults, settings.Secrets, settings.CreateHelmChart)
 	if err != nil {
@@ -46,7 +47,7 @@ func NewPodTemplate(role *model.Role, settings *ExportSettings) (v1.PodTemplateS
 		return v1.PodTemplateSpec{}, err
 	}
 
-	image, err := getContainerImageName(role, settings)
+	image, err := getContainerImageName(role, settings, verbosity)
 	if err != nil {
 		return v1.PodTemplateSpec{}, err
 	}
@@ -94,8 +95,8 @@ func NewPodTemplate(role *model.Role, settings *ExportSettings) (v1.PodTemplateS
 }
 
 // NewPod creates a new Pod for the given role, as well as any objects it depends on
-func NewPod(role *model.Role, settings *ExportSettings) (*v1.Pod, error) {
-	podTemplate, err := NewPodTemplate(role, settings)
+func NewPod(role *model.Role, settings *ExportSettings, verbosity util.Verbosity) (*v1.Pod, error) {
+	podTemplate, err := NewPodTemplate(role, settings, verbosity)
 	if err != nil {
 		return nil, err
 	}
@@ -130,8 +131,8 @@ func NewPod(role *model.Role, settings *ExportSettings) (*v1.Pod, error) {
 }
 
 // getContainerImageName returns the name of the docker image to use for a role
-func getContainerImageName(role *model.Role, settings *ExportSettings) (string, error) {
-	devVersion, err := role.GetRoleDevVersion(settings.Opinions, settings.FissileVersion)
+func getContainerImageName(role *model.Role, settings *ExportSettings, verbosity util.Verbosity) (string, error) {
+	devVersion, err := role.GetRoleDevVersion(settings.Opinions, settings.FissileVersion, verbosity)
 	if err != nil {
 		return "", err
 	}

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/SUSE/fissile/model"
 	"github.com/SUSE/fissile/testhelpers"
+	"github.com/SUSE/fissile/util"
 
 	"github.com/stretchr/testify/assert"
 	yaml "gopkg.in/yaml.v2"
@@ -997,7 +998,7 @@ func TestPodPreFlight(t *testing.T) {
 
 	pod, err := NewPod(role, &ExportSettings{
 		Opinions: model.NewEmptyOpinions(),
-	})
+	}, util.VerbosityDefault)
 	if !assert.NoError(err, "Failed to create pod from role pre-role") {
 		return
 	}
@@ -1039,7 +1040,7 @@ func TestPodPostFlight(t *testing.T) {
 
 	pod, err := NewPod(role, &ExportSettings{
 		Opinions: model.NewEmptyOpinions(),
-	})
+	}, util.VerbosityDefault)
 	if !assert.NoError(err, "Failed to create pod from role post-role") {
 		return
 	}

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/SUSE/fissile/model"
+	"github.com/SUSE/fissile/util"
 	"k8s.io/client-go/pkg/api/resource"
 	meta "k8s.io/client-go/pkg/api/unversioned"
 	"k8s.io/client-go/pkg/api/v1"
@@ -11,14 +12,14 @@ import (
 )
 
 // NewStatefulSet returns a k8s stateful set for the given role
-func NewStatefulSet(role *model.Role, settings *ExportSettings) (*v1beta1.StatefulSet, *v1.List, error) {
+func NewStatefulSet(role *model.Role, settings *ExportSettings, verbosity util.Verbosity) (*v1beta1.StatefulSet, *v1.List, error) {
 	// For each StatefulSet, we need two services -- one for the public (inside
 	// the namespace) endpoint, and one headless service to control the pods.
 	if role == nil {
 		panic(fmt.Sprintf("No role given"))
 	}
 
-	podTemplate, err := NewPodTemplate(role, settings)
+	podTemplate, err := NewPodTemplate(role, settings, verbosity)
 
 	if err != nil {
 		return nil, nil, err

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/SUSE/fissile/model"
 	"github.com/SUSE/fissile/testhelpers"
+	"github.com/SUSE/fissile/util"
 	"github.com/stretchr/testify/assert"
 
 	yaml "gopkg.in/yaml.v2"
@@ -59,7 +60,7 @@ func TestStatefulSetPorts(t *testing.T) {
 	if !assert.NotNil(portDef) {
 		return
 	}
-	statefulset, deps, err := NewStatefulSet(role, &ExportSettings{})
+	statefulset, deps, err := NewStatefulSet(role, &ExportSettings{}, util.VerbosityDefault)
 	if !assert.NoError(err) {
 		return
 	}
@@ -188,7 +189,7 @@ func TestStatefulSetVolumes(t *testing.T) {
 
 	statefulset, _, err := NewStatefulSet(role, &ExportSettings{
 		Opinions: model.NewEmptyOpinions(),
-	})
+	}, util.VerbosityDefault)
 	if !assert.NoError(err) {
 		return
 	}

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/SUSE/fissile/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -222,7 +223,7 @@ func TestGetScriptSignatures(t *testing.T) {
 		},
 	}
 
-	firstHash, _ := refRole.GetScriptSignatures()
+	firstHash, _ := refRole.GetScriptSignatures(util.VerbosityDefault)
 
 	workDir, err := ioutil.TempDir("", "fissile-test-")
 	assert.NoError(err)
@@ -243,13 +244,13 @@ func TestGetScriptSignatures(t *testing.T) {
 		},
 	}
 
-	differentPatchHash, _ := differentPatch.GetScriptSignatures()
+	differentPatchHash, _ := differentPatch.GetScriptSignatures(util.VerbosityDefault)
 	assert.NotEqual(firstHash, differentPatchHash, "role hash should be dependent on patch string")
 
 	err = ioutil.WriteFile(scriptPath, []byte("false\n"), 0644)
 	assert.NoError(err)
 
-	differentPatchFileHash, _ := differentPatch.GetScriptSignatures()
+	differentPatchFileHash, _ := differentPatch.GetScriptSignatures(util.VerbosityDefault)
 	assert.NotEqual(differentPatchFileHash, differentPatchHash, "role manifest hash should be dependent on patch contents")
 }
 
@@ -272,8 +273,8 @@ func TestGetTemplateSignatures(t *testing.T) {
 		},
 	}
 
-	differentTemplateHash1, _ := differentTemplate1.GetTemplateSignatures()
-	differentTemplateHash2, _ := differentTemplate2.GetTemplateSignatures()
+	differentTemplateHash1, _ := differentTemplate1.GetTemplateSignatures(util.VerbosityDefault)
+	differentTemplateHash2, _ := differentTemplate2.GetTemplateSignatures(util.VerbosityDefault)
 	assert.NotEqual(differentTemplateHash1, differentTemplateHash2, "template hash should be dependent on template contents")
 }
 
@@ -315,14 +316,14 @@ func TestGetRoleManifestDevPackageVersion(t *testing.T) {
 	}
 
 	firstManifest := &RoleManifest{Roles: Roles{refRole, altRole}}
-	firstHash, _ := firstManifest.GetRoleManifestDevPackageVersion(firstManifest.Roles, NewEmptyOpinions(), "0.0.0", "")
+	firstHash, _ := firstManifest.GetRoleManifestDevPackageVersion(firstManifest.Roles, NewEmptyOpinions(), "0.0.0", "", util.VerbosityDefault)
 	secondManifest := &RoleManifest{Roles: Roles{altRole, refRole}}
-	secondHash, _ := secondManifest.GetRoleManifestDevPackageVersion(secondManifest.Roles, NewEmptyOpinions(), "0.0.0", "")
+	secondHash, _ := secondManifest.GetRoleManifestDevPackageVersion(secondManifest.Roles, NewEmptyOpinions(), "0.0.0", "", util.VerbosityDefault)
 	assert.Equal(firstHash, secondHash, "role manifest hash should be independent of role order")
 	jobOrderManifest := &RoleManifest{Roles: Roles{wrongJobOrder, altRole}}
-	jobOrderHash, _ := jobOrderManifest.GetRoleManifestDevPackageVersion(jobOrderManifest.Roles, NewEmptyOpinions(), "0.0.0", "")
+	jobOrderHash, _ := jobOrderManifest.GetRoleManifestDevPackageVersion(jobOrderManifest.Roles, NewEmptyOpinions(), "0.0.0", "", util.VerbosityDefault)
 	assert.NotEqual(firstHash, jobOrderHash, "role manifest hash should be dependent on job order")
-	differentExtraHash, _ := firstManifest.GetRoleManifestDevPackageVersion(firstManifest.Roles, NewEmptyOpinions(), "0.0.0", "some string")
+	differentExtraHash, _ := firstManifest.GetRoleManifestDevPackageVersion(firstManifest.Roles, NewEmptyOpinions(), "0.0.0", "some string", util.VerbosityDefault)
 	assert.NotEqual(firstHash, differentExtraHash, "role manifest hash should be dependent on extra string")
 }
 

--- a/util/misc.go
+++ b/util/misc.go
@@ -1,0 +1,12 @@
+package util
+
+// Verbosity is an enumeration describing how verbose we should be
+type Verbosity int
+
+// Known verbosity flags
+const (
+	VerbosityQuiet   = iota // Be more quiet than normal
+	VerbosityDefault = iota // Normal amounts of output
+	VerbosityVerbose = iota // Extra detailed information
+	VerbosityDebug   = iota // Excessive output for troubleshooting
+)


### PR DESCRIPTION
This is more for discussion than actual pull.

It would be nice to have something like an additional logging level, so that we can troubleshoot why image tags are changing.  I don't really like how invasive this patch is though; maybe something like a `termui.UI.Printf()` variant that took logging levels? Or just a levelled logger on top of a writer?