### PR TITLE
Drop docker org from the roleImageName when the outputDirectory is set.

### DIFF
--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -360,8 +360,17 @@ func (j roleBuildJob) Run() {
 			return err
 		}
 
-		roleImageName := GetRoleDevImageName(j.registry, j.organization, j.repository, j.role, devVersion)
-		outputPath := filepath.Join(j.outputDirectory, fmt.Sprintf("%s.tar", roleImageName))
+		var roleImageName string
+		var outputPath string
+
+		if j.outputDirectory == "" {
+			roleImageName = GetRoleDevImageName(j.registry, j.organization, j.repository, j.role, devVersion)
+			outputPath = fmt.Sprintf("%s.tar", roleImageName)
+		} else {
+			roleImageName = GetRoleDevImageName(j.registry, "", j.repository, j.role, devVersion)
+			outputPath = filepath.Join(j.outputDirectory, fmt.Sprintf("%s.tar", roleImageName))
+		}
+
 		if !j.force {
 			if j.outputDirectory == "" {
 				if hasImage, err := j.dockerManager.HasImage(roleImageName); err != nil {

--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -367,7 +367,7 @@ func (j roleBuildJob) Run() {
 			roleImageName = GetRoleDevImageName(j.registry, j.organization, j.repository, j.role, devVersion)
 			outputPath = fmt.Sprintf("%s.tar", roleImageName)
 		} else {
-			roleImageName = GetRoleDevImageName(j.registry, "", j.repository, j.role, devVersion)
+			roleImageName = GetRoleDevImageName("", "", j.repository, j.role, devVersion)
 			outputPath = filepath.Join(j.outputDirectory, fmt.Sprintf("%s.tar", roleImageName))
 		}
 


### PR DESCRIPTION
https://trello.com/c/v6MxcwLW/229-fissile-build-images-output-dir-shouldnt-need-a-splatform-dir-for-uaa

Without outputDirectory use the original form, with org in the name.