### PR TITLE
Add a release target and improve versioning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ build:
 dist:
 	${GIT_ROOT}/make/package
 
+release:
+	${GIT_ROOT}/make/release
+
 docker-deps:
 	${GIT_ROOT}/make/docker-deps
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 #!/usr/bin/env make
 
+ifeq ($(GIT_ROOT),)
 GIT_ROOT:=$(shell git rev-parse --show-toplevel)
+endif
 
 .PHONY: all clean format lint vet bindata build test docker-deps reap dist
 

--- a/make/include/versioning
+++ b/make/include/versioning
@@ -7,6 +7,13 @@ test -n "${XTRACE}" && set -o xtrace
 set -o errexit -o nounset
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+
+if [ -e ${GIT_ROOT}/.version ]; then
+ARTIFACT_NAME=$(awk -F, '{ print $1 }' ${GIT_ROOT}/.version)
+GIT_BRANCH=$(awk -F, '{ print $2 }' ${GIT_ROOT}/.version)
+GIT_DESCRIBE=$(awk -F, '{ print $3 }' ${GIT_ROOT}/.version)
+fi
+
 GIT_DESCRIBE=${GIT_DESCRIBE:-$(git describe --tags --long)}
 GIT_BRANCH=${GIT_BRANCH:-$(git name-rev --name-only HEAD)}
 

--- a/make/release
+++ b/make/release
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+SRC=`basename $(pwd)`
+
+. ${GIT_ROOT}/make/include/versioning
+echo ${ARTIFACT_NAME},${GIT_BRANCH},${GIT_DESCRIBE} > .version
+
+cd ..
+tar --exclude=.git -cJvf fissile-${ARTIFACT_VERSION}.tar.xz $SRC
+cd $SRC

--- a/make/release
+++ b/make/release
@@ -1,11 +1,12 @@
 #!/bin/sh
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
-SRC=`basename $(pwd)`
+pushd .
+SRC==$(basename "$(dirs +0)")
 
 . ${GIT_ROOT}/make/include/versioning
 echo ${ARTIFACT_NAME},${GIT_BRANCH},${GIT_DESCRIBE} > .version
 
 cd ..
 tar --exclude=.git -cJvf fissile-${ARTIFACT_VERSION}.tar.xz $SRC
-cd $SRC
+popd

--- a/make/release
+++ b/make/release
@@ -1,12 +1,11 @@
 #!/bin/sh
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
-pushd .
-SRC==$(basename "$(dirs +0)")
+SRC=$(basename $(dirname $(readlink -f "$0")))
 
 . ${GIT_ROOT}/make/include/versioning
 echo ${ARTIFACT_NAME},${GIT_BRANCH},${GIT_DESCRIBE} > .version
 
-cd ..
+pushd ..
 tar --exclude=.git -cJvf fissile-${ARTIFACT_VERSION}.tar.xz $SRC
 popd


### PR DESCRIPTION
- Add a release target packaging the fissile sources
- Retrieve version information from a .version file if it exists