### PR TITLE
Add docker-network-mode argument to fissile build packages

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -299,7 +299,7 @@ func newPropertyInfo(maybeHash bool) *propertyInfo {
 }
 
 // Compile will compile a list of dev BOSH releases
-func (f *Fissile) Compile(stemcellImageName string, targetPath, roleManifestPath, metricsPath string, roleNames, releaseNames []string, workerCount int, withoutDocker, verbose bool) error {
+func (f *Fissile) Compile(stemcellImageName string, targetPath, roleManifestPath, metricsPath string, roleNames, releaseNames []string, workerCount int, dockerNetworkMode string, withoutDocker, verbose bool) error {
 	if len(f.releases) == 0 {
 		return fmt.Errorf("Releases not loaded")
 	}
@@ -336,7 +336,7 @@ func (f *Fissile) Compile(stemcellImageName string, targetPath, roleManifestPath
 			return fmt.Errorf("Error creating a new compilator: %s", err.Error())
 		}
 	} else {
-		comp, err = compilator.NewDockerCompilator(dockerManager, targetPath, metricsPath, stemcellImageName, compilation.LinuxBase, f.Version, false, f.UI)
+		comp, err = compilator.NewDockerCompilator(dockerManager, targetPath, metricsPath, stemcellImageName, compilation.LinuxBase, f.Version, dockerNetworkMode, false, f.UI)
 		if err != nil {
 			return fmt.Errorf("Error creating a new compilator: %s", err.Error())
 		}

--- a/cmd/build-packages.go
+++ b/cmd/build-packages.go
@@ -31,6 +31,7 @@ compiled once.
 		flagBuildPackagesRoles := buildPackagesViper.GetString("roles")
 		flagBuildPackagesOnlyReleases := buildPackagesViper.GetString("only-releases")
 		flagBuildPackagesWithoutDocker := buildPackagesViper.GetBool("without-docker")
+		flagBuildPackagesDockerNetworkMode := buildPackagesViper.GetString("docker-network-mode")
 		flagBuildPackagesStemcell := buildPackagesViper.GetString("stemcell")
 
 		err := fissile.LoadReleases(
@@ -51,6 +52,7 @@ compiled once.
 			strings.FieldsFunc(flagBuildPackagesRoles, func(r rune) bool { return r == ',' }),
 			strings.FieldsFunc(flagBuildPackagesOnlyReleases, func(r rune) bool { return r == ',' }),
 			flagWorkers,
+			flagBuildPackagesDockerNetworkMode,
 			flagBuildPackagesWithoutDocker,
 			flagVerbose,
 		)
@@ -84,6 +86,13 @@ func init() {
 		"",
 		false,
 		"Build without docker; this may adversely affect your system.  Only supported on Linux, and requires CAP_SYS_ADMIN.",
+	)
+
+	buildPackagesCmd.PersistentFlags().StringP(
+		"docker-network-mode",
+		"",
+		"",
+		"Specify network mode to be used when building with docker. e.g. \"--docker-network-mode host\" is equivalent to \"docker run --network=host\"",
 	)
 
 	buildPackagesCmd.PersistentFlags().StringP(

--- a/compilator/compilator.go
+++ b/compilator/compilator.go
@@ -47,6 +47,7 @@ type Compilator struct {
 	stemcellImageName string
 	baseType          string
 	fissileVersion    string
+	dockerNetworkMode string
 	compilePackage    func(*Compilator, *model.Package) error
 
 	// signalDependencies is a map of
@@ -82,6 +83,7 @@ func NewDockerCompilator(
 	stemcellImageName string,
 	baseType string,
 	fissileVersion string,
+	dockerNetworkMode string,
 	keepContainer bool,
 	ui *termui.UI,
 ) (*Compilator, error) {
@@ -94,6 +96,7 @@ func NewDockerCompilator(
 		baseType:          baseType,
 		fissileVersion:    fissileVersion,
 		compilePackage:    (*Compilator).compilePackageInDocker,
+		dockerNetworkMode: dockerNetworkMode,
 		keepContainer:     keepContainer,
 		ui:                ui,
 
@@ -513,6 +516,7 @@ func (c *Compilator) compilePackageInDocker(pkg *model.Package) (err error) {
 		ImageName:     c.stemcellImageName,
 		Cmd:           []string{"bash", containerScriptPath, pkg.Name, pkg.Version},
 		Mounts:        mounts,
+		NetworkMode:   c.dockerNetworkMode,
 		Volumes:       map[string]map[string]string{sourceMountName: nil},
 		KeepContainer: c.keepContainer,
 		StdoutWriter:  stdoutWriter,

--- a/compilator/compilator_test.go
+++ b/compilator/compilator_test.go
@@ -48,7 +48,7 @@ func TestMain(m *testing.M) {
 func TestCompilationEmpty(t *testing.T) {
 	assert := assert.New(t)
 
-	c, err := NewDockerCompilator(nil, "", "", "", "", "", false, ui)
+	c, err := NewDockerCompilator(nil, "", "", "", "", "", "", false, ui)
 	assert.NoError(err)
 
 	waitCh := make(chan struct{})
@@ -70,7 +70,7 @@ func TestCompilationBasic(t *testing.T) {
 	metrics := file.Name()
 	defer os.Remove(metrics)
 
-	c, err := NewDockerCompilator(nil, "", metrics, "", "", "", false, ui)
+	c, err := NewDockerCompilator(nil, "", metrics, "", "", "", "", false, ui)
 	assert.NoError(err)
 
 	compileChan := make(chan string)
@@ -149,7 +149,7 @@ func TestCompilationSkipCompiled(t *testing.T) {
 
 	assert := assert.New(t)
 
-	c, err := NewDockerCompilator(nil, "", "", "", "", "", false, ui)
+	c, err := NewDockerCompilator(nil, "", "", "", "", "", "", false, ui)
 	assert.NoError(err)
 
 	compileChan := make(chan string)
@@ -174,7 +174,7 @@ func TestCompilationSkipCompiled(t *testing.T) {
 func TestCompilationRoleManifest(t *testing.T) {
 	assert := assert.New(t)
 
-	c, err := NewDockerCompilator(nil, "", "", "", "", "", false, ui)
+	c, err := NewDockerCompilator(nil, "", "", "", "", "", "", false, ui)
 	assert.NoError(err)
 
 	compileChan := make(chan string, 2)
@@ -268,7 +268,7 @@ func doTestContainerKeptAfterCompilationWithErrors(t *testing.T, keepContainer b
 
 	imageName := "splatform/fissile-stemcell-opensuse:42.2"
 
-	comp, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", imageName, compilation.FakeBase, "3.14.15", keepContainer, ui)
+	comp, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", imageName, compilation.FakeBase, "3.14.15", "", keepContainer, ui)
 	assert.NoError(err)
 
 	beforeCompileContainers, err := getContainerIDs(imageName)
@@ -356,7 +356,7 @@ func TestCompilationMultipleErrors(t *testing.T) {
 
 	assert := assert.New(t)
 
-	c, err := NewDockerCompilator(nil, "", "", "", "", "", false, ui)
+	c, err := NewDockerCompilator(nil, "", "", "", "", "", "", false, ui)
 	assert.NoError(err)
 
 	c.compilePackage = func(c *Compilator, pkg *model.Package) error {
@@ -386,7 +386,7 @@ func TestGetPackageStatusCompiled(t *testing.T) {
 	// For this test we assume that the release does not have multiple packages with a single fingerprint
 	assert.NoError(err)
 
-	compilator, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", "fissile-test-compilator", compilation.FakeBase, "3.14.15", false, ui)
+	compilator, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", "fissile-test-compilator", compilation.FakeBase, "3.14.15", "", false, ui)
 	assert.NoError(err)
 
 	compiledPackagePath := filepath.Join(compilationWorkDir, release.Packages[0].Fingerprint, "compiled")
@@ -445,7 +445,7 @@ func TestCompilationParallel(t *testing.T) {
 
 	assert := assert.New(t)
 
-	c, err := NewDockerCompilator(nil, "", "", "", "", "", false, ui)
+	c, err := NewDockerCompilator(nil, "", "", "", "", "", "", false, ui)
 	assert.NoError(err)
 	c.compilePackage = func(c *Compilator, pkg *model.Package) error {
 		mutex.Lock()
@@ -500,7 +500,7 @@ func TestGetPackageStatusNone(t *testing.T) {
 	// For this test we assume that the release does not have multiple packages with a single fingerprint
 	assert.NoError(err)
 
-	compilator, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", "fissile-test-compilator", compilation.FakeBase, "3.14.15", false, ui)
+	compilator, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", "fissile-test-compilator", compilation.FakeBase, "3.14.15", "", false, ui)
 	assert.NoError(err)
 
 	status, err := compilator.isPackageCompiled(release.Packages[0])
@@ -525,7 +525,7 @@ func TestPackageFolderStructure(t *testing.T) {
 	release, err := model.NewDevRelease(ntpReleasePath, "", "", ntpReleasePathBoshCache)
 	assert.NoError(err)
 
-	compilator, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", "fissile-test-compilator", compilation.FakeBase, "3.14.15", false, ui)
+	compilator, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", "fissile-test-compilator", compilation.FakeBase, "3.14.15", "", false, ui)
 	assert.NoError(err)
 
 	err = compilator.createCompilationDirStructure(release.Packages[0])
@@ -556,7 +556,7 @@ func TestPackageDependenciesPreparation(t *testing.T) {
 	release, err := model.NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
 	assert.NoError(err)
 
-	compilator, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", "fissile-test-compilator", compilation.FakeBase, "3.14.15", false, ui)
+	compilator, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", "fissile-test-compilator", compilation.FakeBase, "3.14.15", "", false, ui)
 	assert.NoError(err)
 
 	pkg, err := release.LookupPackage("tor")
@@ -603,7 +603,7 @@ func doTestCompilePackageInDocker(t *testing.T, keepInContainer bool) {
 
 	imageName := "splatform/fissile-stemcell-opensuse:42.2"
 
-	comp, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", imageName, compilation.FakeBase, "3.14.15", keepInContainer, ui)
+	comp, err := NewDockerCompilator(dockerManager, compilationWorkDir, "", imageName, compilation.FakeBase, "3.14.15", "", keepInContainer, ui)
 	assert.NoError(err)
 
 	beforeCompileContainers, err := getContainerIDs(imageName)
@@ -692,7 +692,7 @@ func TestCreateDepBucketsOnChain(t *testing.T) {
 func TestGatherPackages(t *testing.T) {
 	assert := assert.New(t)
 
-	c, err := NewDockerCompilator(nil, "", "", "", "", "", false, ui)
+	c, err := NewDockerCompilator(nil, "", "", "", "", "", "", false, ui)
 	assert.NoError(err)
 
 	releases := genTestCase("ruby-2.5", "go-1.4.1:G", "go-1.4:G")
@@ -715,7 +715,7 @@ func TestRemoveCompiledPackages(t *testing.T) {
 
 	assert := assert.New(t)
 
-	c, err := NewDockerCompilator(nil, "", "", "", "", "", false, ui)
+	c, err := NewDockerCompilator(nil, "", "", "", "", "", "", false, ui)
 	assert.NoError(err)
 
 	releases := genTestCase("ruby-2.5", "consul>go-1.4", "go-1.4")

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -430,6 +430,7 @@ func (d *ImageManager) CreateImage(containerID string, repository string, tag st
 type RunInContainerOpts struct {
 	ContainerName string
 	ImageName     string
+	NetworkMode   string
 	Cmd           []string
 	// Mount points, src -> dest
 	// dest may be special values ContainerInPath, ContainerOutPath
@@ -502,6 +503,7 @@ func (d *ImageManager) RunInContainer(opts RunInContainerOpts) (exitCode int, co
 		HostConfig: &dockerclient.HostConfig{
 			Privileged:     false,
 			Binds:          []string{},
+			NetworkMode:    opts.NetworkMode,
 			ReadonlyRootfs: false,
 		},
 		Name: opts.ContainerName,


### PR DESCRIPTION
or any other option here:
https://docs.docker.com/engine/userguide/networking/

it delegates to NetworkMode in this project:
https://github.com/fsouza/go-dockerclient/blob/4b8b44fdd6d7dc8ef1acec5f21582f339cfbdaaa/container.go#L697

Builds on OBS will work if `--network=host` otherwise we get errors (e.g. can't resolve "localhost" to "127.0.0.1").

@viovanov 