### PR TITLE
Fix the problem with readlink being executed one directory too deep

### DIFF
--- a/make/release
+++ b/make/release
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
-SRC=$(basename $(dirname $(readlink -f "$0")))
+SRC=$(basename $GIT_ROOT)
 
 . ${GIT_ROOT}/make/include/versioning
 echo ${ARTIFACT_NAME},${GIT_BRANCH},${GIT_DESCRIBE} > .version


### PR DESCRIPTION
readlink was executed in the make subfolder and thus the SRC variable was set wrong. Using GIT_ROOT instead as there has to be the source we want to package.