### PR TITLE
run.sh: Add KUBE_COMPONENT_INDEX / KUBE_SERVICE_DOMAIN_SUFFIX

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -71,10 +71,19 @@ configuration:
     required: true
 ```
 
-Note that the variables `DNS_RECORD_NAME` and `IP_ADDRESS` are special and are
-automatically supplied to the container.  They are currently the only special
-variables.  There are also some fields not shown above (as the are not needed
-for NATS):
+Note that there are a few special variables that are automatically supplied to
+the container (via [run.sh]).  They are:
+
+Name | Description
+-- | --
+`DNS_RECORD_NAME` | Hostname of the container
+`IP_ADDRESS` | Primary IP address of the container
+`KUBE_COMPONENT_INDEX` | Numeric index for roles with multiple replicas
+`KUBE_SERVICE_DOMAIN_SUFFIX` | Kubernetes service domain for the deployment
+
+[run.sh]: https://github.com/SUSE/fissile/blob/master/scripts/dockerfiles/run.sh
+
+There are also some fields not shown above (as the are not needed for NATS):
 
 For the role:
 

--- a/docs/validator-description.md
+++ b/docs/validator-description.md
@@ -198,6 +198,8 @@ handle these for generic operation of `fissile`. These are:
    * `IP_ADDRESS`
    * `JWT_SIGNING_PEM`
    * `JWT_SIGNING_PUB`
+   * `KUBE_COMPONENT_INDEX`
+   * `KUBE_SERVICE_DOMAIN_SUFFIX`
    * `NO_PROXY`
    * `http_proxy`
    * `https_proxy`

--- a/model/mustache.go
+++ b/model/mustache.go
@@ -123,5 +123,15 @@ func builtins() ConfigurationVariableSlice {
 			Type:     CVTypeEnv,
 			Internal: true,
 		},
+		&ConfigurationVariable{
+			Name:     "KUBE_COMPONENT_INDEX",
+			Type:     CVTypeEnv,
+			Internal: true,
+		},
+		&ConfigurationVariable{
+			Name:     "KUBE_SERVICE_DOMAIN_SUFFIX",
+			Type:     CVTypeUser, // The user can override this
+			Internal: true,
+		},
 	}
 }

--- a/model/mustache_test.go
+++ b/model/mustache_test.go
@@ -53,7 +53,7 @@ func TestRoleVariables(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(vars)
 
-	expected := []string{"HOME", "FOO", "BAR", "PELERINUL"}
+	expected := []string{"HOME", "FOO", "BAR", "KUBE_SERVICE_DOMAIN_SUFFIX", "PELERINUL"}
 	sort.Strings(expected)
 	var actual []string
 	for _, variable := range vars {


### PR DESCRIPTION
These variables are generic enough that we should just put them in every container.  Update docs and tests to mention this.