### PR TITLE
Generate scaling section in values.yaml

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -939,6 +939,7 @@ func (f *Fissile) generateKubeRoles(outputDir, repository, registry, organizatio
 		Repository:      repository,
 		UseMemoryLimits: useMemoryLimits,
 		FissileVersion:  fissileVersion,
+		RoleManifest:    roleManifest,
 		Opinions:        opinions,
 		Secrets:         refs,
 		CreateHelmChart: createHelmChart,

--- a/helm/config.go
+++ b/helm/config.go
@@ -37,7 +37,7 @@ Tricks:
 
 * Throw an error if the the configuration cannot possibly work
 
-    list.AddNode(NewScalar(`{{ fail "Cannot proceed" }}`, Block("if .count <= 0")))
+    list.AddNode(NewScalar(`{{ fail "Cannot proceed" }}`, Block("if le (int .count) 0")))
 
 * Use a block action to generate multiple list elements
 

--- a/helm/config.go
+++ b/helm/config.go
@@ -253,8 +253,9 @@ func (list *List) Values() []Node {
 }
 
 func (list List) write(enc *Encoder, prefix string) {
+	emptyLines := enc.useEmptyLines(prefix, list.nodes)
 	for _, node := range list.nodes {
-		enc.writeNode(node, &prefix, strings.Repeat(" ", enc.indent-2)+"-")
+		enc.writeNode(node, &prefix, strings.Repeat(" ", enc.indent-2)+"-", emptyLines)
 	}
 }
 
@@ -367,8 +368,13 @@ func (mapping *Mapping) String() string {
 }
 
 func (mapping Mapping) write(enc *Encoder, prefix string) {
+	var nodes []Node
 	for _, namedNode := range mapping.nodes {
-		enc.writeNode(namedNode.node, &prefix, namedNode.name+":")
+		nodes = append(nodes, namedNode.node)
+	}
+	emptyLines := enc.useEmptyLines(prefix, nodes)
+	for _, namedNode := range mapping.nodes {
+		enc.writeNode(namedNode.node, &prefix, namedNode.name+":", emptyLines)
 	}
 }
 
@@ -450,7 +456,7 @@ func (enc *Encoder) Encode(node Node) error {
 	enc.pendingNewline = false
 	fmt.Fprintln(enc, "---")
 	prefix := ""
-	enc.writeNode(node, &prefix, "")
+	enc.writeNode(node, &prefix, "", enc.emptyLines)
 	return enc.err
 }
 
@@ -464,6 +470,27 @@ func (enc *Encoder) Write(buffer []byte) (int, error) {
 		return written, enc.err
 	}
 	return 0, enc.err
+}
+
+// useEmptyLines determines if the elements of a list or mapping should use
+// empty lines. It uses the encoder setting, but disables it for nodes where
+// only a single element has a comment or block action. It is not disabled for
+// the top-level document, so that there can be an empty line between the
+// document comment and the comment of the only element of a document root.
+func (enc *Encoder) useEmptyLines(prefix string, nodes []Node) bool {
+	emptyLines := enc.emptyLines
+	if prefix != "" {
+		specialElements := 0
+		for _, node := range nodes {
+			if node.Block() != "" || node.Comment() != "" {
+				specialElements++
+			}
+		}
+		if specialElements <= 1 {
+			emptyLines = false
+		}
+	}
+	return emptyLines
 }
 
 // useOnce returns the current value of the prefix parameter but replaces it
@@ -516,8 +543,12 @@ func (enc *Encoder) writeComment(prefix *string, comment string) {
 // label contains either the "Name:" for mapping elements, or "-" for list
 // elements. The special value "" is used for the document root, which doesn't
 // have a label.
-func (enc *Encoder) writeNode(node Node, prefix *string, label string) {
-	leadingNewline := enc.emptyLines
+//
+// EmptyLines is set by the caller (via Encode.useEmptyLines) to enc.emptyLines,
+// except when there is only a single element with a comment or block action, in
+// which case it will be `false`.
+func (enc *Encoder) writeNode(node Node, prefix *string, label string, emptyLines bool) {
+	leadingNewline := emptyLines
 	if enc.pendingNewline {
 		fmt.Fprint(enc, "\n")
 		enc.pendingNewline = false
@@ -553,6 +584,6 @@ func (enc *Encoder) writeNode(node Node, prefix *string, label string) {
 		fmt.Fprintln(enc, *prefix+"{{- end }}")
 	}
 	if comment != "" || block != "" {
-		enc.pendingNewline = enc.emptyLines
+		enc.pendingNewline = emptyLines
 	}
 }

--- a/helm/config.go
+++ b/helm/config.go
@@ -443,7 +443,7 @@ func NewEncoder(writer io.Writer, modifiers ...func(*Encoder)) *Encoder {
 	enc := &Encoder{
 		writer:     writer,
 		err:        nil,
-		emptyLines: false,
+		emptyLines: true,
 		indent:     2,
 		wrap:       80,
 	}

--- a/helm/config.go
+++ b/helm/config.go
@@ -522,7 +522,7 @@ func (enc *Encoder) writeComment(prefix *string, comment string) {
 		fmt.Fprintf(enc, "%s#", useOnce(prefix))
 		if len(line) > 0 {
 			written := 0
-			bullet := len(line) >= 2 && (line[:2] == "* " || line[:2] == "- ")
+			bullet := strings.HasPrefix(line, "* ") || strings.HasPrefix(line, "- ")
 			for _, word := range strings.Fields(line) {
 				if written > 0 && len(*prefix)+1+written+1+len(word) > enc.wrap {
 					fmt.Fprintf(enc, "\n%s#", useOnce(prefix))

--- a/helm/config_test.go
+++ b/helm/config_test.go
@@ -502,6 +502,8 @@ List:
 
 func TestHelmWrapLongComments(t *testing.T) {
 	root := NewEmptyMapping()
+	root.AddNode("Bullet", NewScalar("~", Comment("* "+strings.Repeat("abc 12345 ", 5)+"\n\n- "+strings.Repeat("abcd 12345 ", 5))))
+
 	mapping := NewEmptyMapping()
 	word := "1"
 	for i := len(word) + 1; i < 7; i++ {
@@ -517,6 +519,15 @@ func TestHelmWrapLongComments(t *testing.T) {
 	root.AddNode("Nested", mapping)
 
 	expect := `---
+# * abc 12345 abc 12345
+#   abc 12345 abc 12345
+#   abc 12345
+#
+# - abcd 12345 abcd
+#   12345 abcd 12345
+#   abcd 12345 abcd
+#   12345
+Bullet: ~
 # 12 12 12 12 12 12 12
 # 12 12 12
 Key2: ~

--- a/helm/config_test.go
+++ b/helm/config_test.go
@@ -657,15 +657,18 @@ func TestHelmEmptyLines(t *testing.T) {
 	list.AddNode(NewScalar("3", Comment("Another comment")))
 	list.AddNode(NewScalar("4"))
 
-	mapping := NewEmptyMapping()
+	mapping := NewEmptyMapping(Comment("Mapping comment"))
 	mapping.AddNode("List", list)
 	mapping.AddNode("One", NewScalar("1", Comment("First post")))
 	mapping.AddNode("Two", NewScalar("2"))
 	mapping.AddNode("Three", NewScalar("3", Block("if .Values.set")))
 
-	root := NewNodeMapping("Mapping", mapping)
+	root := NewNodeMapping("Mapping", mapping, Comment("Top level comment"))
 
 	expect := `---
+# Top level comment
+
+# Mapping comment
 Mapping:
   List:
   # Some comment
@@ -751,11 +754,26 @@ Mapping:
 	expect = `---
 List:
 - 1
+# A comment
+- 2
+- 3
+`
+	equal(t, root, expect, EmptyLines(true))
+
+	list.AddNode(NewScalar("4", Comment("Another comment")))
+	root = NewNodeMapping("List", list)
+
+	expect = `---
+List:
+- 1
 
 # A comment
 - 2
 
 - 3
+
+# Another comment
+- 4
 `
 	equal(t, root, expect, EmptyLines(true))
 }

--- a/helm/config_test.go
+++ b/helm/config_test.go
@@ -38,7 +38,7 @@ func equal(t *testing.T, config Node, expect string, modifiers ...func(*Encoder)
 	buffer := &bytes.Buffer{}
 	enc := NewEncoder(buffer, EmptyLines(false))
 	enc.Set(modifiers...)
-	assert.Nil(t, enc.Encode(config))
+	assert.NoError(t, enc.Encode(config))
 	assert.Equal(t, expect, buffer.String())
 }
 

--- a/helm/config_test.go
+++ b/helm/config_test.go
@@ -36,7 +36,9 @@ func addBlocks(node Node)   { annotate(node, false, 0) }
 
 func equal(t *testing.T, config Node, expect string, modifiers ...func(*Encoder)) {
 	buffer := &bytes.Buffer{}
-	assert.Nil(t, NewEncoder(buffer, modifiers...).Encode(config))
+	enc := NewEncoder(buffer, EmptyLines(false))
+	enc.Set(modifiers...)
+	assert.Nil(t, enc.Encode(config))
 	assert.Equal(t, expect, buffer.String())
 }
 

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -28,7 +28,7 @@ func NewDeployment(role *model.Role, settings *ExportSettings) (helm.Node, helm.
 	spec.AddNode("selector", newSelector(role.Name))
 	spec.AddNode("template", podTemplate)
 
-	deployment := newKubeConfig("extensions/v1beta1", "Deployment", role.Name)
+	deployment := newKubeConfig("extensions/v1beta1", "Deployment", role.Name, helm.Comment(role.GetLongDescription()))
 	deployment.AddNode("spec", spec)
 
 	return deployment.Sort(), svc, nil

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -1,6 +1,8 @@
 package kube
 
 import (
+	"fmt"
+
 	"github.com/SUSE/fissile/helm"
 	"github.com/SUSE/fissile/model"
 )
@@ -18,7 +20,11 @@ func NewDeployment(role *model.Role, settings *ExportSettings) (helm.Node, helm.
 	}
 
 	spec := helm.NewEmptyMapping()
-	spec.AddInt("replicas", role.Run.Scaling.Min)
+	if settings.CreateHelmChart {
+		spec.Add("replicas", fmt.Sprintf("{{ .Values.sizing.%s.count }}", makeVarName(role.Name)))
+	} else {
+		spec.AddInt("replicas", role.Run.Scaling.Min)
+	}
 	spec.AddNode("selector", newSelector(role.Name))
 	spec.AddNode("template", podTemplate)
 

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -18,18 +18,38 @@ func NewDeployment(role *model.Role, settings *ExportSettings) (helm.Node, helm.
 	if err != nil {
 		return nil, nil, err
 	}
-
 	spec := helm.NewEmptyMapping()
-	if settings.CreateHelmChart {
-		spec.Add("replicas", fmt.Sprintf("{{ .Values.sizing.%s.count }}", makeVarName(role.Name)))
-	} else {
-		spec.AddInt("replicas", role.Run.Scaling.Min)
-	}
 	spec.AddNode("selector", newSelector(role.Name))
 	spec.AddNode("template", podTemplate)
 
 	deployment := newKubeConfig("extensions/v1beta1", "Deployment", role.Name, helm.Comment(role.GetLongDescription()))
-	deployment.AddNode("spec", spec)
+	replicaCheck(role, deployment, spec, svc, settings)
+	deployment.AddNode("spec", spec.Sort())
 
 	return deployment.Sort(), svc, nil
+}
+
+func replicaCheck(role *model.Role, controller *helm.Mapping, spec *helm.Mapping, service helm.Node, settings *ExportSettings) {
+	if !settings.CreateHelmChart {
+		spec.AddInt("replicas", role.Run.Scaling.Min)
+		return
+	}
+
+	roleName := makeVarName(role.Name)
+	spec.Add("replicas", fmt.Sprintf("{{ .Values.sizing.%s.count }}", roleName))
+	if role.Run.Scaling.Min == 0 {
+		block := helm.Block(fmt.Sprintf("if gt (int .Values.sizing.%s.count) 0", roleName))
+		controller.Set(block)
+		if service != nil {
+			service.Set(block)
+		}
+	} else {
+		fail := fmt.Sprintf(`{{ fail "%s must have at least %d instances" }}`, roleName, role.Run.Scaling.Min)
+		block := fmt.Sprintf("if lt (int .Values.sizing.%s.count) %d", roleName, role.Run.Scaling.Min)
+		controller.Add("_minReplicas", fail, helm.Block(block))
+	}
+
+	fail := fmt.Sprintf(`{{ fail "%s cannot have more than %d instances" }}`, roleName, role.Run.Scaling.Max)
+	block := fmt.Sprintf("if gt (int .Values.sizing.%s.count) %d", roleName, role.Run.Scaling.Max)
+	controller.Add("_maxReplicas", fail, helm.Block(block))
 }

--- a/kube/export_settings.go
+++ b/kube/export_settings.go
@@ -12,6 +12,7 @@ type ExportSettings struct {
 	Organization    string
 	UseMemoryLimits bool
 	FissileVersion  string
+	RoleManifest    *model.RoleManifest
 	Opinions        *model.Opinions
 	Secrets         SecretRefMap
 	CreateHelmChart bool

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -98,7 +98,7 @@ func NewPod(role *model.Role, settings *ExportSettings) (helm.Node, error) {
 		return nil, fmt.Errorf("Role %s has unexpected flight stage %s", role.Name, role.Run.FlightStage)
 	}
 
-	pod := newKubeConfig("v1", "Pod", role.Name)
+	pod := newKubeConfig("v1", "Pod", role.Name, helm.Comment(role.GetLongDescription()))
 	pod.AddNode("spec", podTemplate.Get("spec"))
 
 	return pod.Sort(), nil

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -222,7 +222,7 @@ func TestPodGetEnvVars(t *testing.T) {
 			},
 		}
 
-		vars, err := getEnvVars(role, defaults, secrets, false)
+		vars, err := getEnvVars(role, defaults, secrets, &ExportSettings{})
 		assert.NoError(err)
 		assert.NotEmpty(vars)
 

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -37,7 +37,7 @@ func NewStatefulSet(role *model.Role, settings *ExportSettings) (helm.Node, helm
 	spec.AddNode("template", podTemplate)
 	spec.AddNode("volumeClaimTemplates", helm.NewNodeList(claims...))
 
-	statefulSet := newKubeConfig("apps/v1beta1", "StatefulSet", role.Name)
+	statefulSet := newKubeConfig("apps/v1beta1", "StatefulSet", role.Name, helm.Comment(role.GetLongDescription()))
 	statefulSet.AddNode("spec", spec)
 
 	return statefulSet.Sort(), svcList, nil

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -134,3 +134,7 @@ func newKubeConfig(apiVersion, kind string, name string, modifiers ...helm.NodeM
 
 	return mapping
 }
+
+func makeVarName(name string) string {
+	return strings.Replace(name, "-", "_", -1)
+}

--- a/kube/values.go
+++ b/kube/values.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/SUSE/fissile/helm"
 	"github.com/SUSE/fissile/model"
@@ -11,6 +12,9 @@ import (
 func MakeValues(roleManifest *model.RoleManifest, defaults map[string]string) (helm.Node, error) {
 	env := helm.NewEmptyMapping()
 	for name, cv := range model.MakeMapOfVariables(roleManifest) {
+		if strings.HasPrefix(name, "KUBE_SIZING_") {
+			continue
+		}
 		if !cv.Secret || cv.Generator == nil || cv.Generator.Type != model.GeneratorTypePassword {
 			ok, value := cv.Value(defaults)
 			if !ok {

--- a/kube/values.go
+++ b/kube/values.go
@@ -30,15 +30,14 @@ func MakeValues(roleManifest *model.RoleManifest, defaults map[string]string) (h
 		if role.IsDevRole() || role.Run.FlightStage == model.FlightStageManual {
 			continue
 		}
-		comment := fmt.Sprintf("This is dummy description for the %s role.", role.Name)
-		comment += " It should come from the role manifest (which currently doesn't have one)."
-		comment += " This is dummy text."
-		entry := helm.NewEmptyMapping(helm.Comment(comment))
 
+		entry := helm.NewEmptyMapping(helm.Comment(role.GetLongDescription()))
+
+		var comment string
 		if role.Run.Scaling.Min == role.Run.Scaling.Max {
-			comment = fmt.Sprintf("The %s role cannot be scaled", role.Name)
+			comment = fmt.Sprintf("The %s role cannot be scaled.", role.Name)
 		} else {
-			comment = fmt.Sprintf("The %s role can scale between %d and %d instance",
+			comment = fmt.Sprintf("The %s role can scale between %d and %d instances.",
 				role.Name, role.Run.Scaling.Min, role.Run.Scaling.Max)
 		}
 		entry.AddInt("count", role.Run.Scaling.Min, helm.Comment(comment))

--- a/kube/values.go
+++ b/kube/values.go
@@ -20,7 +20,11 @@ func MakeValues(roleManifest *model.RoleManifest, defaults map[string]string) (h
 			if !ok {
 				value = "~"
 			}
-			env.AddNode(name, helm.NewScalar(value, helm.Comment(cv.Description)))
+			comment := cv.Description
+			if cv.Example != "" && cv.Example != value {
+				comment += fmt.Sprintf("\nExample: %s", cv.Example)
+			}
+			env.AddNode(name, helm.NewScalar(value, helm.Comment(comment)))
 		}
 	}
 	env.Sort()

--- a/kube/values.go
+++ b/kube/values.go
@@ -1,6 +1,8 @@
 package kube
 
 import (
+	"fmt"
+
 	"github.com/SUSE/fissile/helm"
 	"github.com/SUSE/fissile/model"
 )
@@ -19,16 +21,46 @@ func MakeValues(roleManifest *model.RoleManifest, defaults map[string]string) (h
 	}
 	env.Sort()
 
-	storageClass := helm.NewEmptyMapping()
-	storageClass.AddNode("persistent", helm.NewScalar("persistent"))
-	storageClass.AddNode("shared", helm.NewScalar("shared"))
+	sizing := helm.NewEmptyMapping()
+	for _, role := range roleManifest.Roles {
+		if role.IsDevRole() || role.Run.FlightStage == model.FlightStageManual {
+			continue
+		}
+		comment := fmt.Sprintf("This is dummy description for the %s role.", role.Name)
+		comment += " It should come from the role manifest (which currently doesn't have one)."
+		comment += " This is dummy text."
+		entry := helm.NewEmptyMapping(helm.Comment(comment))
+
+		if role.Run.Scaling.Min == role.Run.Scaling.Max {
+			comment = fmt.Sprintf("The %s role cannot be scaled", role.Name)
+		} else {
+			comment = fmt.Sprintf("The %s role can scale between %d and %d instance",
+				role.Name, role.Run.Scaling.Min, role.Run.Scaling.Max)
+		}
+		entry.AddInt("count", role.Run.Scaling.Min, helm.Comment(comment))
+		entry.AddInt("memory", role.Run.Memory)
+		entry.AddInt("vcpu_count", role.Run.VirtualCPUs)
+
+		diskSizes := helm.NewEmptyMapping()
+		for _, volume := range role.Run.PersistentVolumes {
+			diskSizes.AddInt(makeVarName(volume.Tag), volume.Size)
+		}
+		for _, volume := range role.Run.SharedVolumes {
+			diskSizes.AddInt(makeVarName(volume.Tag), volume.Size)
+		}
+		if len(diskSizes.Names()) > 0 {
+			entry.AddNode("disk_sizes", diskSizes.Sort())
+		}
+		sizing.AddNode(makeVarName(role.Name), entry)
+	}
 
 	kube := helm.NewEmptyMapping()
 	kube.AddNode("external_ip", helm.NewScalar("192.168.77.77"))
-	kube.AddNode("storage_class", storageClass)
+	kube.AddNode("storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"))
 
 	values := helm.NewEmptyMapping()
 	values.AddNode("env", env)
+	values.AddNode("sizing", sizing.Sort())
 	values.AddNode("kube", kube)
 
 	return values, nil

--- a/model/roles.go
+++ b/model/roles.go
@@ -161,6 +161,7 @@ type ConfigurationVariable struct {
 	Name        string                          `yaml:"name"`
 	Default     interface{}                     `yaml:"default"`
 	Description string                          `yaml:"description"`
+	Example     string                          `yaml:"example"`
 	Generator   *ConfigurationVariableGenerator `yaml:"generator"`
 	Type        CVType                          `yaml:"type"`
 	Internal    bool                            `yaml:"internal,omitempty"`

--- a/model/roles.go
+++ b/model/roles.go
@@ -50,6 +50,7 @@ type RoleManifest struct {
 // Role represents a collection of jobs that are colocated on a container
 type Role struct {
 	Name              string         `yaml:"name"`
+	Description       string         `yaml:"description"`
 	Jobs              Jobs           `yaml:"_,omitempty"`
 	EnvironScripts    []string       `yaml:"environment_scripts"`
 	Scripts           []string       `yaml:"scripts"`
@@ -403,6 +404,29 @@ func (m *RoleManifest) SelectRoles(roleNames []string) (Roles, error) {
 	}
 
 	return results, nil
+}
+
+// GetLongDescription returns the description of the role plus a list of all included jobs
+func (r *Role) GetLongDescription() string {
+	desc := r.Description
+	if len(desc) > 0 {
+		desc += "\n\n"
+	}
+	desc += fmt.Sprintf("The %s role contains the following jobs:", r.Name)
+	var noDesc []string
+	also := ""
+	for _, job := range r.Jobs {
+		if job.Description == "" {
+			noDesc = append(noDesc, job.Name)
+		} else {
+			desc += fmt.Sprintf("\n\n- %s: %s", job.Name, job.Description)
+			also = "Also: "
+		}
+	}
+	if len(noDesc) > 0 {
+		desc += fmt.Sprintf("\n\n%s%s", also, strings.Join(noDesc, ", "))
+	}
+	return desc
 }
 
 // GetScriptPaths returns the paths to the startup / post configgin scripts for a role


### PR DESCRIPTION
Note that memory and vcpu-count are generated but currently not used.

Both the sizing section and the role config files get a long role description as the header. It will start with a `description` from the role manifest (which we don't define yet) followed by a list of all jobs included in the role, including their descriptions. Unfortunately this is currently dominated by descriptions of our dummy bosh roles, so needs to be fixed as well.

The environment variables in `values.yaml` will now include the `example` value in a comment (if it is different from the default value).

Roles with a minimum replica count of 0 will be wrapped to exclude the definition if the actual count is 0.

Roles will include checks that the configured replica count is within the min/max range.

Any config variable of the form `KUBE_SIZING_${ROLE}_COUNT` will expand to the replica count for that role and not be sourced from `values.yaml`.

Comments in the `helm.Node` objects now support bullet lists, which is used in the long role descriptions.