### PR TITLE
Add additional role sizing options

### DIFF
--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -67,8 +67,17 @@ func replicaCheck(role *model.Role, controller *helm.Mapping, service helm.Node,
 	}
 
 	roleName := makeVarName(role.Name)
-	spec.Add("replicas", fmt.Sprintf("{{ .Values.sizing.%s.count }}", roleName))
+	count := fmt.Sprintf(".Values.sizing.%s.count", roleName)
+	if role.Run.Scaling.HA != role.Run.Scaling.Min {
+		// Under HA use HA count if the user hasn't explicitly modified the default count
+		count = fmt.Sprintf("{{ if and .Values.sizing.HA (eq (int %s) %d) -}} %d {{- else -}} {{ %s }} {{- end }}",
+			count, role.Run.Scaling.Min, role.Run.Scaling.HA, count)
+	} else {
+		count = "{{ " + count + " }}"
+	}
+	spec.Add("replicas", count)
 	spec.Sort()
+
 	if role.Run.Scaling.Min == 0 {
 		block := helm.Block(fmt.Sprintf("if gt (int .Values.sizing.%s.count) 0", roleName))
 		controller.Set(block)
@@ -79,6 +88,15 @@ func replicaCheck(role *model.Role, controller *helm.Mapping, service helm.Node,
 		fail := fmt.Sprintf(`{{ fail "%s must have at least %d instances" }}`, roleName, role.Run.Scaling.Min)
 		block := fmt.Sprintf("if lt (int .Values.sizing.%s.count) %d", roleName, role.Run.Scaling.Min)
 		controller.Add("_minReplicas", fail, helm.Block(block))
+
+		if role.Run.Scaling.HA != role.Run.Scaling.Min {
+			fail := fmt.Sprintf(`{{ fail "%s must have at least %d instances for HA" }}`, roleName, role.Run.Scaling.HA)
+			count := fmt.Sprintf(".Values.sizing.%s.count", roleName)
+			// If count != Min then count must be >= HA
+			block := fmt.Sprintf("if and .Values.sizing.HA (and (ne (int %s) %d) (lt (int %s) %d))",
+				count, role.Run.Scaling.Min, count, role.Run.Scaling.HA)
+			controller.Add("_minHAReplicas", fail, helm.Block(block))
+		}
 	}
 
 	fail := fmt.Sprintf(`{{ fail "%s cannot have more than %d instances" }}`, roleName, role.Run.Scaling.Max)

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -102,6 +102,13 @@ func replicaCheck(role *model.Role, controller *helm.Mapping, service helm.Node,
 	fail := fmt.Sprintf(`{{ fail "%s cannot have more than %d instances" }}`, roleName, role.Run.Scaling.Max)
 	block := fmt.Sprintf("if gt (int .Values.sizing.%s.count) %d", roleName, role.Run.Scaling.Max)
 	controller.Add("_maxReplicas", fail, helm.Block(block))
+
+	if role.Run.Scaling.MustBeOdd {
+		fail := fmt.Sprintf(`{{ fail "%s must have an odd instance count" }}`, roleName)
+		block := fmt.Sprintf("if eq (mod (int .Values.sizing.%s.count) 2) 0", roleName)
+		controller.Add("_oddReplicas", fail, helm.Block(block))
+	}
+
 	controller.Sort()
 
 	return nil

--- a/kube/values.go
+++ b/kube/values.go
@@ -30,7 +30,7 @@ func MakeValues(roleManifest *model.RoleManifest, defaults map[string]string) (h
 	}
 	env.Sort()
 
-	sizing := helm.NewMapping()
+	sizing := helm.NewMapping("HA", false)
 	for _, role := range roleManifest.Roles {
 		if role.IsDevRole() || role.Run.FlightStage == model.FlightStageManual {
 			continue
@@ -43,6 +43,11 @@ func MakeValues(roleManifest *model.RoleManifest, defaults map[string]string) (h
 		} else {
 			comment = fmt.Sprintf("The %s role can scale between %d and %d instances.",
 				role.Name, role.Run.Scaling.Min, role.Run.Scaling.Max)
+
+			if role.Run.Scaling.HA != role.Run.Scaling.Min {
+				comment += fmt.Sprintf("\nFor high availability it needs at least %d instances.",
+					role.Run.Scaling.HA)
+			}
 		}
 		entry.Add("count", role.Run.Scaling.Min, helm.Comment(comment))
 		entry.Add("memory", role.Run.Memory)

--- a/kube/values.go
+++ b/kube/values.go
@@ -44,6 +44,9 @@ func MakeValues(roleManifest *model.RoleManifest, defaults map[string]string) (h
 			comment = fmt.Sprintf("The %s role can scale between %d and %d instances.",
 				role.Name, role.Run.Scaling.Min, role.Run.Scaling.Max)
 
+			if role.Run.Scaling.MustBeOdd {
+				comment += "\nThe instance count must be an odd number (not divisible by 2)."
+			}
 			if role.Run.Scaling.HA != role.Run.Scaling.Min {
 				comment += fmt.Sprintf("\nFor high availability it needs at least %d instances.",
 					role.Run.Scaling.HA)

--- a/model/roles.go
+++ b/model/roles.go
@@ -80,9 +80,10 @@ type RoleRun struct {
 
 // RoleRunScaling describes how a role should scale out at runtime
 type RoleRunScaling struct {
-	Min int `yaml:"min"`
-	Max int `yaml:"max"`
-	HA  int `yaml:"ha,omitempty"`
+	Min       int  `yaml:"min"`
+	Max       int  `yaml:"max"`
+	HA        int  `yaml:"ha,omitempty"`
+	MustBeOdd bool `yaml:"must_be_odd,omitempty"`
 }
 
 // RoleRunVolume describes a volume to be attached at runtime

--- a/model/roles.go
+++ b/model/roles.go
@@ -82,6 +82,7 @@ type RoleRun struct {
 type RoleRunScaling struct {
 	Min int `yaml:"min"`
 	Max int `yaml:"max"`
+	HA  int `yaml:"ha,omitempty"`
 }
 
 // RoleRunVolume describes a volume to be attached at runtime
@@ -882,6 +883,10 @@ func validateRoleRun(role *Role, roleManifest *RoleManifest, declared CVMap) val
 	if role.Run == nil {
 		return append(allErrs, validation.Required(
 			fmt.Sprintf("roles[%s].run", role.Name), ""))
+	}
+
+	if role.Run.Scaling != nil && role.Run.Scaling.HA == 0 {
+		role.Run.Scaling.HA = role.Run.Scaling.Min
 	}
 
 	allErrs = append(allErrs, normalizeFlightStage(role)...)


### PR DESCRIPTION
`ha` is the minimum number of instances required for HA. It defaults to `min` if not specified.

`must_be_odd` requires the instance count to be an odd number if this setting is `true`.

Also adds a global switch `sizing.HA` to `values.yaml` (defaults to `false`). If set to `true`, all the templates will use the `ha` value instead of the `min` value for the instance count (unless overridden by the user to a value different from the `min`).

Adds checks that all roles have at least `ha` instances when `sizing.HA` is true.