### PR TITLE
Add extra cli arguments to add more information for image tag calculation.

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -516,7 +516,7 @@ func (f *Fissile) GeneratePackagesRoleTarball(repository string, roleManifest *m
 }
 
 // GenerateRoleImages generates all role images using dev releases
-func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, repository, stemcellImageName, stemcellImageID, metricsPath string, noBuild, force bool, tagDetails string, roleNames []string, workerCount int, roleManifestPath, compiledPackagesPath, lightManifestPath, darkManifestPath, outputDirectory string) error {
+func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, repository, stemcellImageName, stemcellImageID, metricsPath string, noBuild, force bool, tagExtra string, roleNames []string, workerCount int, roleManifestPath, compiledPackagesPath, lightManifestPath, darkManifestPath, outputDirectory string) error {
 	if len(f.releases) == 0 {
 		return fmt.Errorf("Releases not loaded")
 	}
@@ -590,7 +590,7 @@ func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, reposit
 		lightManifestPath,
 		darkManifestPath,
 		metricsPath,
-		tagDetails,
+		tagExtra,
 		f.Version,
 		f.UI,
 	)
@@ -602,7 +602,7 @@ func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, reposit
 }
 
 // ListRoleImages lists all dev role images
-func (f *Fissile) ListRoleImages(registry, organization, repository, roleManifestPath, opinionsPath, darkOpinionsPath string, existingOnDocker, withVirtualSize bool, tagDetails string) error {
+func (f *Fissile) ListRoleImages(registry, organization, repository, roleManifestPath, opinionsPath, darkOpinionsPath string, existingOnDocker, withVirtualSize bool, tagExtra string) error {
 	if withVirtualSize && !existingOnDocker {
 		return fmt.Errorf("Cannot list image virtual sizes if not matching image names with docker")
 	}
@@ -632,7 +632,7 @@ func (f *Fissile) ListRoleImages(registry, organization, repository, roleManifes
 	}
 
 	for _, role := range roleManifest.Roles {
-		devVersion, err := role.GetRoleDevVersion(opinions, tagDetails, f.Version)
+		devVersion, err := role.GetRoleDevVersion(opinions, tagExtra, f.Version)
 		if err != nil {
 			return fmt.Errorf("Error creating role checksum: %s", err.Error())
 		}
@@ -824,7 +824,7 @@ func compareHashes(v1Hash, v2Hash keyHash) *HashDiffs {
 
 // GenerateKube will create a set of configuration files suitable for deployment
 // on Kubernetes
-func (f *Fissile) GenerateKube(roleManifestPath, outputDir, repository, registry, organization, fissileVersion string, defaultFiles []string, tagDetails string, useMemoryLimits, createHelmChart bool, opinions *model.Opinions) error {
+func (f *Fissile) GenerateKube(roleManifestPath, outputDir, repository, registry, organization, fissileVersion string, defaultFiles []string, tagExtra string, useMemoryLimits, createHelmChart bool, opinions *model.Opinions) error {
 
 	roleManifest, err := model.LoadRoleManifest(roleManifestPath, f.releases)
 	if err != nil {
@@ -860,7 +860,7 @@ func (f *Fissile) GenerateKube(roleManifestPath, outputDir, repository, registry
 		}
 	}
 
-	return f.generateKubeRoles(outputDir, repository, registry, organization, tagDetails, fissileVersion, roleManifest, defaults, refs, useMemoryLimits, createHelmChart, opinions)
+	return f.generateKubeRoles(outputDir, repository, registry, organization, tagExtra, fissileVersion, roleManifest, defaults, refs, useMemoryLimits, createHelmChart, opinions)
 }
 
 func (f *Fissile) generateSecrets(outputDir string, secrets helm.Node, roleManifest *model.RoleManifest, createHelmChart bool) error {
@@ -932,7 +932,7 @@ func (f *Fissile) generateBoshTaskRole(outputFile *os.File, role *model.Role, se
 	return nil
 }
 
-func (f *Fissile) generateKubeRoles(outputDir, repository, registry, organization, tagDetails, fissileVersion string, roleManifest *model.RoleManifest, defaults map[string]string, refs kube.SecretRefMap, useMemoryLimits bool, createHelmChart bool, opinions *model.Opinions) error {
+func (f *Fissile) generateKubeRoles(outputDir, repository, registry, organization, tagExtra, fissileVersion string, roleManifest *model.RoleManifest, defaults map[string]string, refs kube.SecretRefMap, useMemoryLimits bool, createHelmChart bool, opinions *model.Opinions) error {
 	settings := &kube.ExportSettings{
 		Defaults:        defaults,
 		Registry:        registry,
@@ -940,7 +940,7 @@ func (f *Fissile) generateKubeRoles(outputDir, repository, registry, organizatio
 		Repository:      repository,
 		UseMemoryLimits: useMemoryLimits,
 		FissileVersion:  fissileVersion,
-		TagDetails:      tagDetails,
+		TagExtra:        tagExtra,
 		RoleManifest:    roleManifest,
 		Opinions:        opinions,
 		Secrets:         refs,

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -516,7 +516,7 @@ func (f *Fissile) GeneratePackagesRoleTarball(repository string, roleManifest *m
 }
 
 // GenerateRoleImages generates all role images using dev releases
-func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, repository, stemcellImageName, stemcellImageID, metricsPath string, noBuild, force bool, roleNames []string, workerCount int, roleManifestPath, compiledPackagesPath, lightManifestPath, darkManifestPath, outputDirectory string) error {
+func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, repository, stemcellImageName, stemcellImageID, metricsPath string, noBuild, force bool, tagDetails string, roleNames []string, workerCount int, roleManifestPath, compiledPackagesPath, lightManifestPath, darkManifestPath, outputDirectory string) error {
 	if len(f.releases) == 0 {
 		return fmt.Errorf("Releases not loaded")
 	}
@@ -590,6 +590,7 @@ func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, reposit
 		lightManifestPath,
 		darkManifestPath,
 		metricsPath,
+		tagDetails,
 		f.Version,
 		f.UI,
 	)
@@ -601,7 +602,7 @@ func (f *Fissile) GenerateRoleImages(targetPath, registry, organization, reposit
 }
 
 // ListRoleImages lists all dev role images
-func (f *Fissile) ListRoleImages(registry, organization, repository, roleManifestPath, opinionsPath, darkOpinionsPath string, existingOnDocker, withVirtualSize bool) error {
+func (f *Fissile) ListRoleImages(registry, organization, repository, roleManifestPath, opinionsPath, darkOpinionsPath string, existingOnDocker, withVirtualSize bool, tagDetails string) error {
 	if withVirtualSize && !existingOnDocker {
 		return fmt.Errorf("Cannot list image virtual sizes if not matching image names with docker")
 	}
@@ -631,7 +632,7 @@ func (f *Fissile) ListRoleImages(registry, organization, repository, roleManifes
 	}
 
 	for _, role := range roleManifest.Roles {
-		devVersion, err := role.GetRoleDevVersion(opinions, f.Version)
+		devVersion, err := role.GetRoleDevVersion(opinions, tagDetails, f.Version)
 		if err != nil {
 			return fmt.Errorf("Error creating role checksum: %s", err.Error())
 		}
@@ -823,7 +824,7 @@ func compareHashes(v1Hash, v2Hash keyHash) *HashDiffs {
 
 // GenerateKube will create a set of configuration files suitable for deployment
 // on Kubernetes
-func (f *Fissile) GenerateKube(roleManifestPath, outputDir, repository, registry, organization, fissileVersion string, defaultFiles []string, useMemoryLimits, createHelmChart bool, opinions *model.Opinions) error {
+func (f *Fissile) GenerateKube(roleManifestPath, outputDir, repository, registry, organization, fissileVersion string, defaultFiles []string, tagDetails string, useMemoryLimits, createHelmChart bool, opinions *model.Opinions) error {
 
 	roleManifest, err := model.LoadRoleManifest(roleManifestPath, f.releases)
 	if err != nil {
@@ -859,7 +860,7 @@ func (f *Fissile) GenerateKube(roleManifestPath, outputDir, repository, registry
 		}
 	}
 
-	return f.generateKubeRoles(outputDir, repository, registry, organization, fissileVersion, roleManifest, defaults, refs, useMemoryLimits, createHelmChart, opinions)
+	return f.generateKubeRoles(outputDir, repository, registry, organization, tagDetails, fissileVersion, roleManifest, defaults, refs, useMemoryLimits, createHelmChart, opinions)
 }
 
 func (f *Fissile) generateSecrets(outputDir string, secrets helm.Node, roleManifest *model.RoleManifest, createHelmChart bool) error {
@@ -931,7 +932,7 @@ func (f *Fissile) generateBoshTaskRole(outputFile *os.File, role *model.Role, se
 	return nil
 }
 
-func (f *Fissile) generateKubeRoles(outputDir, repository, registry, organization, fissileVersion string, roleManifest *model.RoleManifest, defaults map[string]string, refs kube.SecretRefMap, useMemoryLimits bool, createHelmChart bool, opinions *model.Opinions) error {
+func (f *Fissile) generateKubeRoles(outputDir, repository, registry, organization, tagDetails, fissileVersion string, roleManifest *model.RoleManifest, defaults map[string]string, refs kube.SecretRefMap, useMemoryLimits bool, createHelmChart bool, opinions *model.Opinions) error {
 	settings := &kube.ExportSettings{
 		Defaults:        defaults,
 		Registry:        registry,
@@ -939,6 +940,7 @@ func (f *Fissile) generateKubeRoles(outputDir, repository, registry, organizatio
 		Repository:      repository,
 		UseMemoryLimits: useMemoryLimits,
 		FissileVersion:  fissileVersion,
+		TagDetails:      tagDetails,
 		RoleManifest:    roleManifest,
 		Opinions:        opinions,
 		Secrets:         refs,

--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -46,7 +46,7 @@ type RoleImageBuilder struct {
 	compiledPackagesPath string
 	targetPath           string
 	metricsPath          string
-	tagDetails           string
+	tagExtra             string
 	fissileVersion       string
 	lightOpinionsPath    string
 	darkOpinionsPath     string
@@ -54,7 +54,7 @@ type RoleImageBuilder struct {
 }
 
 // NewRoleImageBuilder creates a new RoleImageBuilder
-func NewRoleImageBuilder(repository, compiledPackagesPath, targetPath, lightOpinionsPath, darkOpinionsPath, metricsPath, tagDetails, fissileVersion string, ui *termui.UI) (*RoleImageBuilder, error) {
+func NewRoleImageBuilder(repository, compiledPackagesPath, targetPath, lightOpinionsPath, darkOpinionsPath, metricsPath, tagExtra, fissileVersion string, ui *termui.UI) (*RoleImageBuilder, error) {
 	if err := os.MkdirAll(targetPath, 0755); err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func NewRoleImageBuilder(repository, compiledPackagesPath, targetPath, lightOpin
 		targetPath:           targetPath,
 		metricsPath:          metricsPath,
 		fissileVersion:       fissileVersion,
-		tagDetails:           tagDetails,
+		tagExtra:             tagExtra,
 		lightOpinionsPath:    lightOpinionsPath,
 		darkOpinionsPath:     darkOpinionsPath,
 		ui:                   ui,
@@ -353,7 +353,7 @@ func (j roleBuildJob) Run() {
 			return err
 		}
 
-		devVersion, err := j.role.GetRoleDevVersion(opinions, j.builder.tagDetails, j.builder.fissileVersion)
+		devVersion, err := j.role.GetRoleDevVersion(opinions, j.builder.tagExtra, j.builder.fissileVersion)
 		if err != nil {
 			return err
 		}

--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -46,6 +46,7 @@ type RoleImageBuilder struct {
 	compiledPackagesPath string
 	targetPath           string
 	metricsPath          string
+	tagDetails           string
 	fissileVersion       string
 	lightOpinionsPath    string
 	darkOpinionsPath     string
@@ -53,7 +54,7 @@ type RoleImageBuilder struct {
 }
 
 // NewRoleImageBuilder creates a new RoleImageBuilder
-func NewRoleImageBuilder(repository, compiledPackagesPath, targetPath, lightOpinionsPath, darkOpinionsPath, metricsPath, fissileVersion string, ui *termui.UI) (*RoleImageBuilder, error) {
+func NewRoleImageBuilder(repository, compiledPackagesPath, targetPath, lightOpinionsPath, darkOpinionsPath, metricsPath, tagDetails, fissileVersion string, ui *termui.UI) (*RoleImageBuilder, error) {
 	if err := os.MkdirAll(targetPath, 0755); err != nil {
 		return nil, err
 	}
@@ -64,6 +65,7 @@ func NewRoleImageBuilder(repository, compiledPackagesPath, targetPath, lightOpin
 		targetPath:           targetPath,
 		metricsPath:          metricsPath,
 		fissileVersion:       fissileVersion,
+		tagDetails:           tagDetails,
 		lightOpinionsPath:    lightOpinionsPath,
 		darkOpinionsPath:     darkOpinionsPath,
 		ui:                   ui,
@@ -351,7 +353,7 @@ func (j roleBuildJob) Run() {
 			return err
 		}
 
-		devVersion, err := j.role.GetRoleDevVersion(opinions, j.builder.fissileVersion)
+		devVersion, err := j.role.GetRoleDevVersion(opinions, j.builder.tagDetails, j.builder.fissileVersion)
 		if err != nil {
 			return err
 		}

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -49,7 +49,7 @@ func TestGenerateRoleImageDockerfile(t *testing.T) {
 	torOpinionsDir := filepath.Join(workDir, "../test-assets/tor-opinions")
 	lightOpinionsPath := filepath.Join(torOpinionsDir, "opinions.yml")
 	darkOpinionsPath := filepath.Join(torOpinionsDir, "dark-opinions.yml")
-	roleImageBuilder, err := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, lightOpinionsPath, darkOpinionsPath, "", "6.28.30", ui)
+	roleImageBuilder, err := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, lightOpinionsPath, darkOpinionsPath, "", "deadbeef", "6.28.30", ui)
 	assert.NoError(err)
 
 	var dockerfileContents bytes.Buffer
@@ -102,7 +102,7 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 	lightOpinionsPath := filepath.Join(torOpinionsDir, "opinions.yml")
 	darkOpinionsPath := filepath.Join(torOpinionsDir, "dark-opinions.yml")
 
-	roleImageBuilder, err := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, lightOpinionsPath, darkOpinionsPath, "", "6.28.30", ui)
+	roleImageBuilder, err := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, lightOpinionsPath, darkOpinionsPath, "", "deadbeef", "6.28.30", ui)
 	assert.NoError(err)
 
 	runScriptContents, err := roleImageBuilder.generateRunScript(roleManifest.Roles[0])
@@ -156,7 +156,7 @@ func TestGenerateRoleImageJobsConfig(t *testing.T) {
 	torOpinionsDir := filepath.Join(workDir, "../test-assets/tor-opinions")
 	lightOpinionsPath := filepath.Join(torOpinionsDir, "opinions.yml")
 	darkOpinionsPath := filepath.Join(torOpinionsDir, "dark-opinions.yml")
-	roleImageBuilder, err := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, lightOpinionsPath, darkOpinionsPath, "", "6.28.30", ui)
+	roleImageBuilder, err := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, lightOpinionsPath, darkOpinionsPath, "", "deadbeef", "6.28.30", ui)
 	assert.NoError(err)
 
 	jobsConfigContents, err := roleImageBuilder.generateJobsConfig(roleManifest.Roles[0])
@@ -206,7 +206,7 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 	lightOpinionsPath := filepath.Join(torOpinionsDir, "opinions.yml")
 	darkOpinionsPath := filepath.Join(torOpinionsDir, "dark-opinions.yml")
 
-	roleImageBuilder, err := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, lightOpinionsPath, darkOpinionsPath, "", "6.28.30", ui)
+	roleImageBuilder, err := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, lightOpinionsPath, darkOpinionsPath, "", "deadbeef", "6.28.30", ui)
 	assert.NoError(err)
 
 	torPkg := getPackage(roleManifest.Roles, "myrole", "tor", "tor")
@@ -430,6 +430,7 @@ func TestBuildRoleImages(t *testing.T) {
 		lightOpinionsPath,
 		darkOpinionsPath,
 		"",
+		"deadbeef",
 		"6.28.30",
 		ui,
 	)

--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -11,7 +11,7 @@ var (
 	flagBuildHelmOutputDir       string
 	flagBuildHelmDefaultEnvFiles []string
 	flagBuildHelmUseMemoryLimits bool
-	flagBuildHelmVersion         string
+	flagBuildHelmTagExtra        string
 )
 
 // buildHelmCmd represents the helm command
@@ -24,6 +24,7 @@ var buildHelmCmd = &cobra.Command{
 		flagBuildHelmOutputDir = buildHelmViper.GetString("output-dir")
 		flagBuildHelmDefaultEnvFiles = splitNonEmpty(buildHelmViper.GetString("defaults-file"), ",")
 		flagBuildHelmUseMemoryLimits = buildHelmViper.GetBool("use-memory-limits")
+		flagBuildHelmTagExtra = buildHelmViper.GetString("tag-extra")
 
 		err := fissile.LoadReleases(
 			flagRelease,
@@ -51,7 +52,7 @@ var buildHelmCmd = &cobra.Command{
 			flagDockerOrganization,
 			fissile.Version,
 			flagBuildHelmDefaultEnvFiles,
-			flagBuildHelmVersion,
+			flagBuildHelmTagExtra,
 			flagBuildHelmUseMemoryLimits,
 			true,
 			opinions,
@@ -87,10 +88,10 @@ func init() {
 	)
 
 	buildHelmCmd.PersistentFlags().StringP(
-		"version",
+		"tag-extra",
 		"",
 		"",
-		"Additional version information to use in computing the image tags",
+		"Additional information to use in computing the image tags",
 	)
 
 	buildHelmViper.BindPFlags(buildHelmCmd.PersistentFlags())

--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -11,6 +11,7 @@ var (
 	flagBuildHelmOutputDir       string
 	flagBuildHelmDefaultEnvFiles []string
 	flagBuildHelmUseMemoryLimits bool
+	flagBuildHelmVersion         string
 )
 
 // buildHelmCmd represents the helm command
@@ -50,6 +51,7 @@ var buildHelmCmd = &cobra.Command{
 			flagDockerOrganization,
 			fissile.Version,
 			flagBuildHelmDefaultEnvFiles,
+			flagBuildHelmVersion,
 			flagBuildHelmUseMemoryLimits,
 			true,
 			opinions,
@@ -82,6 +84,13 @@ func init() {
 		"",
 		true,
 		"Include memory limits when generating helm chart",
+	)
+
+	buildHelmCmd.PersistentFlags().StringP(
+		"version",
+		"",
+		"",
+		"Additional version information to use in computing the image tags",
 	)
 
 	buildHelmViper.BindPFlags(buildHelmCmd.PersistentFlags())

--- a/cmd/build-images.go
+++ b/cmd/build-images.go
@@ -16,6 +16,7 @@ var (
 
 	flagBuildImagesStemcell   string
 	flagBuildImagesStemcellID string
+	flagBuildImagesVersion    string
 )
 
 // buildImagesCmd represents the images command
@@ -50,6 +51,7 @@ from other specs.  At most one is allowed.
 		flagOutputDirectory = buildImagesViper.GetString("output-directory")
 		flagBuildImagesStemcell = buildImagesViper.GetString("stemcell")
 		flagBuildImagesStemcellID = buildImagesViper.GetString("stemcell-id")
+		flagBuildImagesVersion = buildImagesViper.GetString("version")
 
 		err := fissile.LoadReleases(
 			flagRelease,
@@ -76,6 +78,7 @@ from other specs.  At most one is allowed.
 			flagMetrics,
 			flagBuildImagesNoBuild,
 			flagBuildImagesForce,
+			flagBuildImagesVersion,
 			strings.FieldsFunc(flagBuildImagesRoles, func(r rune) bool { return r == ',' }),
 			flagWorkers,
 			flagRoleManifest,
@@ -141,6 +144,13 @@ func init() {
 		"",
 		"",
 		"Docker image ID for the stemcell (intended for CI)",
+	)
+
+	buildImagesCmd.PersistentFlags().StringP(
+		"version",
+		"",
+		"",
+		"Additional version information to use in computing the image tags",
 	)
 
 	buildImagesViper.BindPFlags(buildImagesCmd.PersistentFlags())

--- a/cmd/build-images.go
+++ b/cmd/build-images.go
@@ -16,7 +16,7 @@ var (
 
 	flagBuildImagesStemcell   string
 	flagBuildImagesStemcellID string
-	flagBuildImagesVersion    string
+	flagBuildImagesTagExtra   string
 )
 
 // buildImagesCmd represents the images command
@@ -51,7 +51,7 @@ from other specs.  At most one is allowed.
 		flagOutputDirectory = buildImagesViper.GetString("output-directory")
 		flagBuildImagesStemcell = buildImagesViper.GetString("stemcell")
 		flagBuildImagesStemcellID = buildImagesViper.GetString("stemcell-id")
-		flagBuildImagesVersion = buildImagesViper.GetString("version")
+		flagBuildImagesTagExtra = buildImagesViper.GetString("tag-extra")
 
 		err := fissile.LoadReleases(
 			flagRelease,
@@ -78,7 +78,7 @@ from other specs.  At most one is allowed.
 			flagMetrics,
 			flagBuildImagesNoBuild,
 			flagBuildImagesForce,
-			flagBuildImagesVersion,
+			flagBuildImagesTagExtra,
 			strings.FieldsFunc(flagBuildImagesRoles, func(r rune) bool { return r == ',' }),
 			flagWorkers,
 			flagRoleManifest,
@@ -147,10 +147,10 @@ func init() {
 	)
 
 	buildImagesCmd.PersistentFlags().StringP(
-		"version",
+		"tag-extra",
 		"",
 		"",
-		"Additional version information to use in computing the image tags",
+		"Additional information to use in computing the image tags",
 	)
 
 	buildImagesViper.BindPFlags(buildImagesCmd.PersistentFlags())

--- a/cmd/build-kube.go
+++ b/cmd/build-kube.go
@@ -11,6 +11,7 @@ var (
 	flagBuildKubeOutputDir       string
 	flagBuildKubeDefaultEnvFiles []string
 	flagBuildKubeUseMemoryLimits bool
+	flagBuildKubeVersion         string
 )
 
 // buildKubeCmd represents the kube command
@@ -50,6 +51,7 @@ var buildKubeCmd = &cobra.Command{
 			flagDockerOrganization,
 			fissile.Version,
 			flagBuildKubeDefaultEnvFiles,
+			flagBuildKubeVersion,
 			flagBuildKubeUseMemoryLimits,
 			false,
 			opinions,
@@ -82,6 +84,13 @@ func init() {
 		"",
 		true,
 		"Include memory limits when generating kube configurations",
+	)
+
+	buildKubeCmd.PersistentFlags().StringP(
+		"version",
+		"",
+		"",
+		"Additional version information to use in computing the image tags",
 	)
 
 	buildKubeViper.BindPFlags(buildKubeCmd.PersistentFlags())

--- a/cmd/build-kube.go
+++ b/cmd/build-kube.go
@@ -11,7 +11,7 @@ var (
 	flagBuildKubeOutputDir       string
 	flagBuildKubeDefaultEnvFiles []string
 	flagBuildKubeUseMemoryLimits bool
-	flagBuildKubeVersion         string
+	flagBuildKubeTagExtra        string
 )
 
 // buildKubeCmd represents the kube command
@@ -24,6 +24,7 @@ var buildKubeCmd = &cobra.Command{
 		flagBuildKubeOutputDir = buildKubeViper.GetString("output-dir")
 		flagBuildKubeDefaultEnvFiles = splitNonEmpty(buildKubeViper.GetString("defaults-file"), ",")
 		flagBuildKubeUseMemoryLimits = buildKubeViper.GetBool("use-memory-limits")
+		flagBuildKubeTagExtra = buildKubeViper.GetString("tag-extra")
 
 		err := fissile.LoadReleases(
 			flagRelease,
@@ -51,7 +52,7 @@ var buildKubeCmd = &cobra.Command{
 			flagDockerOrganization,
 			fissile.Version,
 			flagBuildKubeDefaultEnvFiles,
-			flagBuildKubeVersion,
+			flagBuildKubeTagExtra,
 			flagBuildKubeUseMemoryLimits,
 			false,
 			opinions,
@@ -87,10 +88,10 @@ func init() {
 	)
 
 	buildKubeCmd.PersistentFlags().StringP(
-		"version",
+		"tag-extra",
 		"",
 		"",
-		"Additional version information to use in computing the image tags",
+		"Additional information to use in computing the image tags",
 	)
 
 	buildKubeViper.BindPFlags(buildKubeCmd.PersistentFlags())

--- a/cmd/show-image.go
+++ b/cmd/show-image.go
@@ -8,7 +8,7 @@ import (
 var (
 	flagShowImageDockerOnly bool
 	flagShowImageWithSizes  bool
-	flagShowImageVersion    string
+	flagShowImageTagExtra   string
 )
 
 // showImageCmd represents the image command
@@ -25,7 +25,7 @@ This command is useful in conjunction with docker (e.g. ` + "`docker rmi $(fissi
 
 		flagShowImageDockerOnly = showImagesViper.GetBool("docker-only")
 		flagShowImageWithSizes = showImagesViper.GetBool("with-sizes")
-		flagShowImageVersion = showImagesViper.GetString("version")
+		flagShowImageTagExtra = showImagesViper.GetString("tag-extra")
 
 		err := fissile.LoadReleases(
 			flagRelease,
@@ -46,7 +46,7 @@ This command is useful in conjunction with docker (e.g. ` + "`docker rmi $(fissi
 			flagDarkOpinions,
 			flagShowImageDockerOnly,
 			flagShowImageWithSizes,
-			flagShowImageVersion,
+			flagShowImageTagExtra,
 		)
 	},
 }
@@ -73,10 +73,10 @@ func init() {
 	)
 
 	showImageCmd.PersistentFlags().StringP(
-		"version",
+		"tag-extra",
 		"",
 		"",
-		"Additional version information to use in computing the image tags",
+		"Additional information to use in computing the image tags",
 	)
 
 	showImagesViper.BindPFlags(showImageCmd.PersistentFlags())

--- a/cmd/show-image.go
+++ b/cmd/show-image.go
@@ -8,6 +8,7 @@ import (
 var (
 	flagShowImageDockerOnly bool
 	flagShowImageWithSizes  bool
+	flagShowImageVersion    string
 )
 
 // showImageCmd represents the image command
@@ -22,8 +23,9 @@ This command is useful in conjunction with docker (e.g. ` + "`docker rmi $(fissi
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		flagShowImageDockerOnly = viper.GetBool("docker-only")
-		flagShowImageWithSizes = viper.GetBool("with-sizes")
+		flagShowImageDockerOnly = showImagesViper.GetBool("docker-only")
+		flagShowImageWithSizes = showImagesViper.GetBool("with-sizes")
+		flagShowImageVersion = showImagesViper.GetString("version")
 
 		err := fissile.LoadReleases(
 			flagRelease,
@@ -44,11 +46,16 @@ This command is useful in conjunction with docker (e.g. ` + "`docker rmi $(fissi
 			flagDarkOpinions,
 			flagShowImageDockerOnly,
 			flagShowImageWithSizes,
+			flagShowImageVersion,
 		)
 	},
 }
 
+var showImagesViper = viper.New()
+
 func init() {
+	initViper(showImagesViper)
+
 	showCmd.AddCommand(showImageCmd)
 
 	showImageCmd.PersistentFlags().BoolP(
@@ -65,5 +72,12 @@ func init() {
 		"If the flag is set, also show image virtual sizes; only works if the --docker-only flag is set",
 	)
 
-	viper.BindPFlags(showImageCmd.PersistentFlags())
+	showImageCmd.PersistentFlags().StringP(
+		"version",
+		"",
+		"",
+		"Additional version information to use in computing the image tags",
+	)
+
+	showImagesViper.BindPFlags(showImageCmd.PersistentFlags())
 }

--- a/kube/export_settings.go
+++ b/kube/export_settings.go
@@ -12,6 +12,7 @@ type ExportSettings struct {
 	Organization    string
 	UseMemoryLimits bool
 	FissileVersion  string
+	TagDetails      string
 	RoleManifest    *model.RoleManifest
 	Opinions        *model.Opinions
 	Secrets         SecretRefMap

--- a/kube/export_settings.go
+++ b/kube/export_settings.go
@@ -12,7 +12,7 @@ type ExportSettings struct {
 	Organization    string
 	UseMemoryLimits bool
 	FissileVersion  string
-	TagDetails      string
+	TagExtra        string
 	RoleManifest    *model.RoleManifest
 	Opinions        *model.Opinions
 	Secrets         SecretRefMap

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -106,7 +106,7 @@ func NewPod(role *model.Role, settings *ExportSettings) (helm.Node, error) {
 
 // getContainerImageName returns the name of the docker image to use for a role
 func getContainerImageName(role *model.Role, settings *ExportSettings) (string, error) {
-	devVersion, err := role.GetRoleDevVersion(settings.Opinions, settings.FissileVersion)
+	devVersion, err := role.GetRoleDevVersion(settings.Opinions, settings.TagDetails, settings.FissileVersion)
 	if err != nil {
 		return "", err
 	}

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -106,7 +106,7 @@ func NewPod(role *model.Role, settings *ExportSettings) (helm.Node, error) {
 
 // getContainerImageName returns the name of the docker image to use for a role
 func getContainerImageName(role *model.Role, settings *ExportSettings) (string, error) {
-	devVersion, err := role.GetRoleDevVersion(settings.Opinions, settings.TagDetails, settings.FissileVersion)
+	devVersion, err := role.GetRoleDevVersion(settings.Opinions, settings.TagExtra, settings.FissileVersion)
 	if err != nil {
 		return "", err
 	}

--- a/model/roles.go
+++ b/model/roles.go
@@ -532,7 +532,7 @@ func (r *Role) GetTemplateSignatures() (string, error) {
 // role dev version, and the aggregated spec and opinion
 // information. In this manner opinion changes cause a rebuild of the
 // associated role images.
-func (r *Role) GetRoleDevVersion(opinions *Opinions, fissileVersion string) (string, error) {
+func (r *Role) GetRoleDevVersion(opinions *Opinions, tagDetails, fissileVersion string) (string, error) {
 
 	// Basic role version
 	devVersion, err := r.getRoleJobAndPackagesSignature()
@@ -549,6 +549,7 @@ func (r *Role) GetRoleDevVersion(opinions *Opinions, fissileVersion string) (str
 	signatures := []string{
 		devVersion,
 		fissileVersion,
+		tagDetails,
 	}
 
 	// Job order comes from the role manifest, and is sort of

--- a/model/roles.go
+++ b/model/roles.go
@@ -532,7 +532,7 @@ func (r *Role) GetTemplateSignatures() (string, error) {
 // role dev version, and the aggregated spec and opinion
 // information. In this manner opinion changes cause a rebuild of the
 // associated role images.
-func (r *Role) GetRoleDevVersion(opinions *Opinions, tagDetails, fissileVersion string) (string, error) {
+func (r *Role) GetRoleDevVersion(opinions *Opinions, tagExtra, fissileVersion string) (string, error) {
 
 	// Basic role version
 	devVersion, err := r.getRoleJobAndPackagesSignature()
@@ -549,7 +549,7 @@ func (r *Role) GetRoleDevVersion(opinions *Opinions, tagDetails, fissileVersion 
 	signatures := []string{
 		devVersion,
 		fissileVersion,
-		tagDetails,
+		tagExtra,
 	}
 
 	// Job order comes from the role manifest, and is sort of

--- a/model/roles.go
+++ b/model/roles.go
@@ -356,26 +356,6 @@ func LoadRoleManifest(manifestFilePath string, releases []*Release) (*RoleManife
 	return &roleManifest, nil
 }
 
-// GetRoleManifestDevPackageVersion gets the aggregate signature of all the packages
-func (m *RoleManifest) GetRoleManifestDevPackageVersion(roles Roles, opinions *Opinions, fissileVersion, extra string) (string, error) {
-	// Make sure our roles are sorted, to have consistent output
-	roles = append(Roles{}, roles...)
-	sort.Sort(roles)
-
-	hasher := sha1.New()
-	hasher.Write([]byte(extra))
-
-	for _, role := range roles {
-		version, err := role.GetRoleDevVersion(opinions, fissileVersion)
-		if err != nil {
-			return "", err
-		}
-		hasher.Write([]byte(version))
-	}
-
-	return hex.EncodeToString(hasher.Sum(nil)), nil
-}
-
 // LookupRole will find the given role in the role manifest
 func (m *RoleManifest) LookupRole(roleName string) *Role {
 	for _, role := range m.Roles {

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -278,55 +278,6 @@ func TestGetTemplateSignatures(t *testing.T) {
 	assert.NotEqual(differentTemplateHash1, differentTemplateHash2, "template hash should be dependent on template contents")
 }
 
-func TestGetRoleManifestDevPackageVersion(t *testing.T) {
-	assert := assert.New(t)
-
-	refRole := &Role{
-		Name: "bbb",
-		Jobs: Jobs{
-			{
-				SHA1: "Role 2 Job 1",
-				Packages: Packages{
-					{Name: "aaa", SHA1: "Role 2 Job 1 Package 1"},
-					{Name: "bbb", SHA1: "Role 2 Job 1 Package 2"},
-				},
-			},
-			{
-				SHA1: "Role 2 Job 2",
-				Packages: Packages{
-					{Name: "ccc", SHA1: "Role 2 Job 2 Package 1"},
-				},
-			},
-		},
-	}
-	wrongJobOrder := &Role{
-		Name: refRole.Name,
-		Jobs: Jobs{refRole.Jobs[1], refRole.Jobs[0]},
-	}
-	altRole := &Role{
-		Name: "aaa",
-		Jobs: Jobs{
-			{
-				SHA1: "Role 1 Job 1",
-				Packages: Packages{
-					{Name: "zzz", SHA1: "Role 1	 Job 1 Package 1"},
-				},
-			},
-		},
-	}
-
-	firstManifest := &RoleManifest{Roles: Roles{refRole, altRole}}
-	firstHash, _ := firstManifest.GetRoleManifestDevPackageVersion(firstManifest.Roles, NewEmptyOpinions(), "0.0.0", "")
-	secondManifest := &RoleManifest{Roles: Roles{altRole, refRole}}
-	secondHash, _ := secondManifest.GetRoleManifestDevPackageVersion(secondManifest.Roles, NewEmptyOpinions(), "0.0.0", "")
-	assert.Equal(firstHash, secondHash, "role manifest hash should be independent of role order")
-	jobOrderManifest := &RoleManifest{Roles: Roles{wrongJobOrder, altRole}}
-	jobOrderHash, _ := jobOrderManifest.GetRoleManifestDevPackageVersion(jobOrderManifest.Roles, NewEmptyOpinions(), "0.0.0", "")
-	assert.NotEqual(firstHash, jobOrderHash, "role manifest hash should be dependent on job order")
-	differentExtraHash, _ := firstManifest.GetRoleManifestDevPackageVersion(firstManifest.Roles, NewEmptyOpinions(), "0.0.0", "some string")
-	assert.NotEqual(firstHash, differentExtraHash, "role manifest hash should be dependent on extra string")
-}
-
 func TestLoadRoleManifestVariablesSortedError(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
https://trello.com/c/HaqnE735/391-fissile-doesnt-have-enough-information-to-generate-good-docker-image-tags-when-scf-changes

Implementation should be complete. Unit tests pass.
Still needs testing within the context of a vagrant box building images.

Hm ... Coming to dislike the current name of the new option (`--version`).
The env var for that is `FISSILE_VERSION`, and completely does __not__ mean that.
To confusing.
A better env name would be `FISSILE_TAG_EXTRA`, and option `--tag-extra`.
Going for that now.

SCF PR = https://github.com/SUSE/scf/pull/1148 (🚧 No fissile master build yet)

This PR now ready for review.