### PR TITLE
helm: drop default liveness probe

### DIFF
--- a/helm/config.go
+++ b/helm/config.go
@@ -287,8 +287,16 @@ func NewMapping(values ...interface{}) *Mapping {
 	return mapping
 }
 
-// Add a single named node at the end of the list.
+// Add a single named node at the end of the list, replacing any existing
+// entries of the same name.
 func (mapping *Mapping) Add(name string, value interface{}, modifiers ...NodeModifier) {
+	for i, node := range mapping.nodes {
+		if node.name == name {
+			mapping.nodes = append(mapping.nodes[:i], mapping.nodes[i+1:]...)
+			// There can be at most one node with this name
+			break
+		}
+	}
 	mapping.nodes = append(mapping.nodes, namedNode{name: name, node: NewNode(value, modifiers...)})
 }
 

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -15,9 +15,6 @@ import (
 	"github.com/SUSE/fissile/model"
 )
 
-// monitPort is the port monit runs on in the pods
-const monitPort = 2289
-
 // defaultInitialDelaySeconds is the default initial delay for liveness probes
 const defaultInitialDelaySeconds = 600
 
@@ -272,31 +269,17 @@ func getContainerLivenessProbe(role *model.Role) (helm.Node, error) {
 		return nil, nil
 	}
 
-	var probe *helm.Mapping
+	var err error
+	probe := helm.NewMapping()
 	if role.Run.HealthCheck != nil && role.Run.HealthCheck.Liveness != nil {
-		var complete bool
-		var err error
-		probe, complete, err = configureContainerProbe(role, "liveness", role.Run.HealthCheck.Liveness)
+		probe, _, err = configureContainerProbe(role, "liveness", role.Run.HealthCheck.Liveness)
 
 		if probe.Get("initialDelaySeconds").String() == "0" {
 			probe.Add("initialDelaySeconds", defaultInitialDelaySeconds)
 		}
-		if complete || err != nil {
-			return probe, err
-		}
-	}
-	if role.Type != model.RoleTypeBosh {
-		return nil, nil
 	}
 
-	if probe == nil {
-		probe = helm.NewMapping()
-	}
-	if probe.Get("initialDelaySeconds") == nil {
-		probe.Add("initialDelaySeconds", defaultInitialDelaySeconds)
-	}
-	probe.Add("tcpSocket", helm.NewMapping("port", monitPort))
-	return probe.Sort(), nil
+	return probe, err
 }
 
 func getContainerReadinessProbe(role *model.Role) (helm.Node, error) {

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -269,17 +269,19 @@ func getContainerLivenessProbe(role *model.Role) (helm.Node, error) {
 		return nil, nil
 	}
 
-	var err error
-	probe := helm.NewMapping()
 	if role.Run.HealthCheck != nil && role.Run.HealthCheck.Liveness != nil {
-		probe, _, err = configureContainerProbe(role, "liveness", role.Run.HealthCheck.Liveness)
+		probe, complete, err := configureContainerProbe(role, "liveness", role.Run.HealthCheck.Liveness)
 
 		if probe.Get("initialDelaySeconds").String() == "0" {
 			probe.Add("initialDelaySeconds", defaultInitialDelaySeconds)
 		}
+		if complete || err != nil {
+			return probe, err
+		}
 	}
 
-	return probe, err
+	// No custom probes; we don't have a default one either.
+	return nil, nil
 }
 
 func getContainerReadinessProbe(role *model.Role) (helm.Node, error) {

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -487,15 +487,6 @@ func TestPodGetContainerLivenessProbe(t *testing.T) {
 					path:   "/path"`,
 		},
 		{
-			desc: "Defaults, liveness timeout",
-			input: &model.HealthProbe{
-				Timeout: 20,
-			},
-			expected: `---
-				timeoutSeconds:      20
-				initialDelaySeconds: 600`,
-		},
-		{
 			desc: "Port probe, liveness timeout",
 			input: &model.HealthProbe{
 				Port:    1234,

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -58,37 +58,39 @@ type Sample struct {
 }
 
 func (sample *Sample) check(t *testing.T, helmConfig helm.Node, err error) {
-	assert := assert.New(t)
-	if sample.err != "" {
-		assert.EqualError(err, sample.err, sample.desc)
-		return
-	}
-	if !assert.NoError(err, sample.desc) {
-		return
-	}
-	if sample.expected == "" {
-		assert.Nil(helmConfig)
-		return
-	}
-	actualYAML := &bytes.Buffer{}
-	if helmConfig != nil && !assert.NoError(helm.NewEncoder(actualYAML).Encode(helmConfig)) {
-		return
-	}
-	expectedYAML := strings.Replace(sample.expected, "-\t", "-   ", -1)
-	expectedYAML = strings.Replace(expectedYAML, "\t", "    ", -1)
+	t.Run(sample.desc, func(t *testing.T) {
+		assert := assert.New(t)
+		if sample.err != "" {
+			assert.EqualError(err, sample.err, sample.desc)
+			return
+		}
+		if !assert.NoError(err, sample.desc) {
+			return
+		}
+		if sample.expected == "" {
+			assert.Nil(helmConfig)
+			return
+		}
+		actualYAML := &bytes.Buffer{}
+		if helmConfig != nil && !assert.NoError(helm.NewEncoder(actualYAML).Encode(helmConfig)) {
+			return
+		}
+		expectedYAML := strings.Replace(sample.expected, "-\t", "-   ", -1)
+		expectedYAML = strings.Replace(expectedYAML, "\t", "    ", -1)
 
-	var expected, actual interface{}
-	if !assert.NoError(yaml.Unmarshal([]byte(expectedYAML), &expected)) {
-		assert.Fail(expectedYAML)
-		return
-	}
-	if !assert.NoError(yaml.Unmarshal(actualYAML.Bytes(), &actual)) {
-		assert.Fail(actualYAML.String())
-		return
-	}
-	if !testhelpers.IsYAMLSubset(assert, expected, actual) {
-		assert.Fail("Not a proper YAML subset", "*Actual*\n%s\n*Expected*\n%s\n", actualYAML.String(), expectedYAML)
-	}
+		var expected, actual interface{}
+		if !assert.NoError(yaml.Unmarshal([]byte(expectedYAML), &expected)) {
+			assert.Fail(expectedYAML)
+			return
+		}
+		if !assert.NoError(yaml.Unmarshal(actualYAML.Bytes(), &actual)) {
+			assert.Fail(actualYAML.String())
+			return
+		}
+		if !testhelpers.IsYAMLSubset(assert, expected, actual) {
+			assert.Fail("Not a proper YAML subset", "*Actual*\n%s\n*Expected*\n%s\n", actualYAML.String(), expectedYAML)
+		}
+	})
 }
 
 func TestPodGetVolumes(t *testing.T) {
@@ -354,12 +356,9 @@ func TestPodGetContainerLivenessProbe(t *testing.T) {
 
 	samples := []Sample{
 		{
-			desc:  "Always on, defaults",
-			input: nil,
-			expected: `---
-				initialDelaySeconds: 600
-				tcpSocket:
-					port: 2289`,
+			desc:     "Always on, defaults",
+			input:    nil,
+			expected: `---`,
 		},
 		{
 			desc: "Port probe",
@@ -494,9 +493,7 @@ func TestPodGetContainerLivenessProbe(t *testing.T) {
 			},
 			expected: `---
 				timeoutSeconds:      20
-				initialDelaySeconds: 600
-				tcpSocket:
-					port: 2289`,
+				initialDelaySeconds: 600`,
 		},
 		{
 			desc: "Port probe, liveness timeout",

--- a/testhelpers/serialization_helper.go
+++ b/testhelpers/serialization_helper.go
@@ -23,7 +23,11 @@ func isYAMLSubsetInner(assert *assert.Assertions, expected, actual interface{}, 
 
 	switch expectedValue.Kind() {
 	case reflect.Map:
-		if !assert.Equal(reflect.Map, actualValue.Kind(), "expected YAML path %s to be a %s, but is actually %s", yamlPath, expectedValue.Type(), actualValue.Type()) {
+		actualType := "<nil>"
+		if actualValue.IsValid() {
+			actualType = fmt.Sprintf("%s", actualValue.Type())
+		}
+		if !assert.Equal(reflect.Map, actualValue.Kind(), "expected YAML path %s to be a %s, but is actually %s", yamlPath, expectedValue.Type(), actualType) {
 			return false
 		}
 		success := true


### PR DESCRIPTION
It wasn't doing anything useful for us; since the pre-start scripts run before monit comes up, that taking too long brings down the pod (and often breaks migrations).

The role manifest still could have explicit liveness probes.