### PR TITLE
Add support for RBAC accounts / roles

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -72,6 +72,14 @@ func NewPodTemplate(role *model.Role, settings ExportSettings) (helm.Node, error
 	spec.Add("imagePullSecrets", helm.NewList(imagePullSecrets))
 	spec.Add("dnsPolicy", "ClusterFirst")
 	spec.Add("restartPolicy", "Always")
+	if role.Run.ServiceAccount != "" {
+		// This role requires a custom service account
+		block := helm.Block("")
+		if settings.CreateHelmChart {
+			block = helm.Block(authModeRBAC)
+		}
+		spec.Add("serviceAccountName", role.Run.ServiceAccount, block)
+	}
 	spec.Sort()
 
 	podTemplate := helm.NewMapping()

--- a/kube/rbac.go
+++ b/kube/rbac.go
@@ -1,0 +1,78 @@
+package kube
+
+import (
+	"fmt"
+
+	"github.com/SUSE/fissile/helm"
+	"github.com/SUSE/fissile/model"
+)
+
+const authModeRBAC = `if eq (printf "%s" .Values.kube.auth) "rbac"`
+
+// NewRBACAccount creates a new (Kubernetes RBAC) service account and associated
+// bindings.
+func NewRBACAccount(name string, account model.AuthAccount, settings ExportSettings) ([]helm.Node, error) {
+	block := helm.Block("")
+	if settings.CreateHelmChart {
+		block = helm.Block(authModeRBAC)
+	}
+
+	var resources []helm.Node
+
+	// If we want to modify the default account, there's no need to create it
+	// first -- it already exists
+	if name != "default" {
+		accountYAML := newTypeMeta("v1", "ServiceAccount", block)
+		accountYAML.Add("metadata", helm.NewMapping("name", name))
+		resources = append(resources, accountYAML)
+	}
+
+	for _, role := range account.Roles {
+		binding := newTypeMeta("rbac.authorization.k8s.io/v1beta1", "RoleBinding", block)
+		binding.Add("metadata", helm.NewMapping("name", fmt.Sprintf("%s-%s-binding", name, role)))
+		subjects := helm.NewList(helm.NewMapping(
+			"kind", "ServiceAccount",
+			"name", name))
+		binding.Add("subjects", subjects)
+		binding.Add("roleRef", helm.NewMapping(
+			"kind", "Role",
+			"name", role,
+			"apiGroup", "rbac.authorization.k8s.io"))
+		resources = append(resources, binding)
+	}
+
+	return resources, nil
+}
+
+// NewRBACRole creates a new (Kubernetes RBAC) role
+func NewRBACRole(name string, role model.AuthRole, settings ExportSettings) (helm.Node, error) {
+	rules := helm.NewList()
+	for _, ruleSpec := range role {
+		rule := helm.NewMapping()
+		APIGroups := helm.NewList()
+		for _, APIGroup := range ruleSpec.APIGroups {
+			APIGroups.Add(APIGroup)
+		}
+		rule.Add("apiGroups", APIGroups)
+		resources := helm.NewList()
+		for _, resource := range ruleSpec.Resources {
+			resources.Add(resource)
+		}
+		rule.Add("resources", resources)
+		verbs := helm.NewList()
+		for _, verb := range ruleSpec.Verbs {
+			verbs.Add(verb)
+		}
+		rule.Add("verbs", verbs)
+		rules.Add(rule.Sort())
+	}
+
+	container := newTypeMeta("rbac.authorization.k8s.io/v1beta1", "Role")
+	if settings.CreateHelmChart {
+		container.Set(helm.Block(authModeRBAC))
+	}
+	container.Add("metadata", helm.NewMapping("name", name))
+	container.Add("rules", rules)
+
+	return container.Sort(), nil
+}

--- a/kube/values.go
+++ b/kube/values.go
@@ -86,6 +86,7 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	kube.Add("storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"))
 	kube.Add("registry", registryInfo)
 	kube.Add("organization", settings.Organization)
+	kube.Add("auth", nil)
 
 	values := helm.NewMapping()
 	values.Add("env", env)

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -409,6 +409,40 @@ func TestLoadRoleManifestRunEnvDocker(t *testing.T) {
 	assert.Nil(roleManifest)
 }
 
+func TestLoadRoleManifestMissingRBACAccount(t *testing.T) {
+	assert := assert.New(t)
+
+	workDir, err := os.Getwd()
+	assert.NoError(err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(err)
+
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/rbac-missing-account.yml")
+	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
+	assert.EqualError(err, `roles[myrole].run.service-account: Not found: "missing-account"`)
+	assert.Nil(roleManifest)
+}
+
+func TestLoadRoleManifestMissingRBACRole(t *testing.T) {
+	assert := assert.New(t)
+
+	workDir, err := os.Getwd()
+	assert.NoError(err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(err)
+
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/rbac-missing-role.yml")
+	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release})
+	assert.EqualError(err, `configuration.auth.accounts[test-account].roles: Not found: "missing-role"`)
+	assert.Nil(roleManifest)
+}
+
 func TestLoadRoleManifestRunGeneral(t *testing.T) {
 	assert := assert.New(t)
 

--- a/test-assets/role-manifests/generate-auth.yml
+++ b/test-assets/role-manifests/generate-auth.yml
@@ -1,0 +1,25 @@
+---
+roles:
+- name: non-default
+  run:
+    service-account: non-default
+- name: default
+  run: {}
+configuration:
+  auth:
+    accounts:
+      non-default:
+        roles:
+        - extra-permissions
+      default:
+        roles:
+        - pointless
+    roles:
+      extra-permissions:
+      - apiGroups: ['']
+        resources: [pods]
+        verbs: [create, get, list, update, patch, delete]
+      pointless:
+      - apiGroups: ['']
+        resources: [bird]
+        verbs: [fly]

--- a/test-assets/role-manifests/rbac-missing-account.yml
+++ b/test-assets/role-manifests/rbac-missing-account.yml
@@ -1,0 +1,5 @@
+---
+roles:
+- name: myrole
+  run:
+    service-account: missing-account

--- a/test-assets/role-manifests/rbac-missing-role.yml
+++ b/test-assets/role-manifests/rbac-missing-role.yml
@@ -1,0 +1,10 @@
+---
+configuration:
+  auth:
+    accounts:
+      test-account:
+        roles:
+        - missing-role
+        - valid-role
+    roles:
+      valid-role: []


### PR DESCRIPTION
For RBAC-based deployments, by default no permissions are granted to the service accounts.  We may end up needing some (to e.g. patch pod annotations).  This provides a mechanism to specify service accounts for
each role, and what (RBAC) roles are applied to each account.

Currently, this means we need to add a chunk to the role manifest to define the service account permissions for configgin to work:
```yaml
configuration:
  auth:
    roles:
      configgin-role:
      - apiGroups: [""] # In kube rbac, empty string means the default group
        resources: [pods]
        verbs: [get, list, patch]
      - apiGroups: [""]
        resources: [services]
        verbs: [get]
    accounts:
      default:
        roles: [configgin-role]
```

I'm not sure yet if we should just hard code that into fissile (which would mean updating fissile when we need to modify configgin… perhaps not the best way to go).