### PR TITLE
Hide environment variables from values.yaml

### DIFF
--- a/kube/values.go
+++ b/kube/values.go
@@ -12,7 +12,7 @@ import (
 func MakeValues(settings ExportSettings) (helm.Node, error) {
 	env := helm.NewMapping()
 	for name, cv := range model.MakeMapOfVariables(settings.RoleManifest) {
-		if strings.HasPrefix(name, "KUBE_SIZING_") {
+		if strings.HasPrefix(name, "KUBE_SIZING_") || cv.Type == model.CVTypeEnv {
 			continue
 		}
 		if !cv.Secret || cv.Generator == nil || cv.Generator.Type != model.GeneratorTypePassword {


### PR DESCRIPTION
Configuration variables of the `CVTypeEnv` are not settable by the user but provided by the software, so listing them in `values.yaml` is confusing because they cannot be overridden.