### PR TITLE
Remove secret generation from kube configs

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -837,6 +837,24 @@ func (f *Fissile) GenerateKube(roleManifestPath string, defaultFiles []string, s
 		return err
 	}
 
+	cvs := model.MakeMapOfVariables(settings.RoleManifest)
+	for key, value := range cvs {
+		if !value.Secret {
+			delete(cvs, key)
+		}
+	}
+	// cvs now holds only the secrets.
+	var secrets helm.Node
+	secrets, settings.Secrets, err = kube.MakeSecrets(cvs, settings)
+	if err != nil {
+		return err
+	}
+
+	err = f.generateSecrets("secrets.yaml", secrets, settings)
+	if err != nil {
+		return err
+	}
+
 	registryCredentials, err := kube.MakeRegistryCredentials(settings)
 	if err != nil {
 		return err

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -837,24 +837,6 @@ func (f *Fissile) GenerateKube(roleManifestPath string, defaultFiles []string, s
 		return err
 	}
 
-	cvs := model.MakeMapOfVariables(settings.RoleManifest)
-	for key, value := range cvs {
-		if !value.Secret {
-			delete(cvs, key)
-		}
-	}
-	// cvs now holds only the secrets.
-	var secrets helm.Node
-	secrets, settings.Secrets, err = kube.MakeSecrets(cvs, settings)
-	if err != nil {
-		return err
-	}
-
-	err = f.generateSecrets("secrets.yaml", secrets, settings)
-	if err != nil {
-		return err
-	}
-
 	registryCredentials, err := kube.MakeRegistryCredentials(settings)
 	if err != nil {
 		return err

--- a/kube/secret.go
+++ b/kube/secret.go
@@ -1,14 +1,5 @@
 package kube
 
-import (
-	"encoding/base64"
-	"fmt"
-	"strings"
-
-	"github.com/SUSE/fissile/helm"
-	"github.com/SUSE/fissile/model"
-)
-
 // SecretRef is an entry in the SecretRefMap
 type SecretRef struct {
 	Secret string
@@ -21,45 +12,3 @@ type SecretRef struct {
 // but then we would have to replicate the transform at the place
 // where the mapping is used. I prefer to do it only once.
 type SecretRefMap map[string]SecretRef
-
-// MakeSecrets creates Secret KubeConfig filled with the
-// key/value pairs from the specified map. It further returns a map
-// showing which original CV name maps to what secret+key combination.
-func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, SecretRefMap, error) {
-	refs := make(map[string]SecretRef)
-
-	data := helm.NewMapping()
-	for name, cv := range secrets {
-		var value string
-		if settings.CreateHelmChart {
-			switch {
-			case cv.Generator == nil || cv.Generator.Type != model.GeneratorTypePassword:
-				errString := fmt.Sprintf("%s configuration missing", cv.Name)
-				value = fmt.Sprintf(`{{ required "%s" .Values.env.%s | b64enc | quote }}`, errString, cv.Name)
-			case cv.Generator.Type == model.GeneratorTypePassword:
-				value = "{{ randAlphaNum 32 | b64enc | quote }}"
-			}
-		} else {
-			ok, value := cv.Value(settings.Defaults)
-			if !ok {
-				return nil, nil, fmt.Errorf("Secret '%s' has no value", name)
-			}
-			value = base64.StdEncoding.EncodeToString([]byte(value))
-		}
-
-		// (**) "secrets need to be lowercase and can only use dashes, not underscores"
-		key := strings.ToLower(strings.Replace(name, "_", "-", -1))
-
-		data.Add(key, helm.NewNode(value, helm.Comment(cv.Description)))
-		refs[name] = SecretRef{
-			Secret: "secret",
-			Key:    key,
-		}
-	}
-	data.Sort()
-
-	secret := newKubeConfig("v1", "Secret", "secret")
-	secret.Add("data", data)
-
-	return secret.Sort(), refs, nil
-}

--- a/kube/secret.go
+++ b/kube/secret.go
@@ -41,7 +41,7 @@ func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, Secre
 		}
 
 		if settings.CreateHelmChart {
-			if cv.Generator != nil {
+			if cv.Generator != nil && cv.Generator.Type == model.GeneratorTypePassword {
 				// There is a generator, so it will be created by a job during runtime
 				continue
 			} else {


### PR DESCRIPTION
Secret generation is done as a job now. This allows them to be kept across upgrades instead of regenerating them.