### PR TITLE
Drop the compatibility code for handling the deprecated /opt/hcf directory of older stemcells.

### DIFF
--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -87,7 +87,7 @@ func (r *RoleImageBuilder) NewDockerPopulator(role *model.Role, baseImageName st
 					continue
 				}
 
-				releaseDir := filepath.Join("root/opt/scf/share/doc", roleJob.Release.Name)
+				releaseDir := filepath.Join("root/opt/fissile/share/doc", roleJob.Release.Name)
 
 				for filename, contents := range roleJob.Release.License.Files {
 					err := util.WriteToTarStream(tarWriter, contents, tar.Header{
@@ -172,7 +172,7 @@ func (r *RoleImageBuilder) NewDockerPopulator(role *model.Role, baseImageName st
 		// Copy role startup scripts
 		for script, sourceScriptPath := range role.GetScriptPaths() {
 			err := util.CopyFileToTarStream(tarWriter, sourceScriptPath, &tar.Header{
-				Name: filepath.Join("root/opt/scf/startup", script),
+				Name: filepath.Join("root/opt/fissile/startup", script),
 			})
 			if err != nil {
 				return fmt.Errorf("Error writing script %s: %s", script, err)
@@ -185,7 +185,7 @@ func (r *RoleImageBuilder) NewDockerPopulator(role *model.Role, baseImageName st
 			return err
 		}
 		err = util.WriteToTarStream(tarWriter, runScriptContents, tar.Header{
-			Name: "root/opt/scf/run.sh",
+			Name: "root/opt/fissile/run.sh",
 		})
 		if err != nil {
 			return err
@@ -196,19 +196,19 @@ func (r *RoleImageBuilder) NewDockerPopulator(role *model.Role, baseImageName st
 			return err
 		}
 		err = util.WriteToTarStream(tarWriter, jobsConfigContents, tar.Header{
-			Name: "root/opt/scf/job_config.json",
+			Name: "root/opt/fissile/job_config.json",
 		})
 		if err != nil {
 			return err
 		}
 
-		// Create env2conf templates file in /opt/scf/env2conf.yml
+		// Create env2conf templates file in /opt/fissile/env2conf.yml
 		configTemplatesBytes, err := yaml.Marshal(role.Configuration.Templates)
 		if err != nil {
 			return err
 		}
 		err = util.WriteToTarStream(tarWriter, configTemplatesBytes, tar.Header{
-			Name: "root/opt/scf/env2conf.yml",
+			Name: "root/opt/fissile/env2conf.yml",
 		})
 		if err != nil {
 			return err
@@ -285,7 +285,7 @@ func (r *RoleImageBuilder) generateJobsConfig(role *model.Role) ([]byte, error) 
 			files[src] = dest
 
 			if index == 0 {
-				files["/opt/scf/monitrc.erb"] = "/etc/monitrc"
+				files["/opt/fissile/monitrc.erb"] = "/etc/monitrc"
 			}
 		}
 

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -107,18 +107,18 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 
 	runScriptContents, err := roleImageBuilder.generateRunScript(roleManifest.Roles[0])
 	assert.NoError(err)
-	assert.Contains(string(runScriptContents), "source /opt/scf/startup/environ.sh")
+	assert.Contains(string(runScriptContents), "source /opt/fissile/startup/environ.sh")
 	assert.Contains(string(runScriptContents), "source /environ/script/with/absolute/path.sh")
-	assert.NotContains(string(runScriptContents), "/opt/scf/startup/environ/script/with/absolute/path.sh")
-	assert.NotContains(string(runScriptContents), "/opt/scf/startup//environ/script/with/absolute/path.sh")
-	assert.Contains(string(runScriptContents), "bash /opt/scf/startup/myrole.sh")
+	assert.NotContains(string(runScriptContents), "/opt/fissile/startup/environ/script/with/absolute/path.sh")
+	assert.NotContains(string(runScriptContents), "/opt/fissile/startup//environ/script/with/absolute/path.sh")
+	assert.Contains(string(runScriptContents), "bash /opt/fissile/startup/myrole.sh")
 	assert.Contains(string(runScriptContents), "bash /script/with/absolute/path.sh")
-	assert.NotContains(string(runScriptContents), "/opt/scf/startup/script/with/absolute/path.sh")
-	assert.NotContains(string(runScriptContents), "/opt/scf/startup//script/with/absolute/path.sh")
-	assert.Contains(string(runScriptContents), "bash /opt/scf/startup/post_config_script.sh")
+	assert.NotContains(string(runScriptContents), "/opt/fissile/startup/script/with/absolute/path.sh")
+	assert.NotContains(string(runScriptContents), "/opt/fissile/startup//script/with/absolute/path.sh")
+	assert.Contains(string(runScriptContents), "bash /opt/fissile/startup/post_config_script.sh")
 	assert.Contains(string(runScriptContents), "bash /var/vcap/jobs/myrole/pre-start")
-	assert.NotContains(string(runScriptContents), "/opt/scf/startup/var/vcap/jobs/myrole/pre-start")
-	assert.NotContains(string(runScriptContents), "/opt/scf//startup/var/vcap/jobs/myrole/pre-start")
+	assert.NotContains(string(runScriptContents), "/opt/fissile/startup/var/vcap/jobs/myrole/pre-start")
+	assert.NotContains(string(runScriptContents), "/opt/fissile//startup/var/vcap/jobs/myrole/pre-start")
 	assert.Contains(string(runScriptContents), "monit -vI &")
 
 	runScriptContents, err = roleImageBuilder.generateRunScript(roleManifest.Roles[1])
@@ -218,9 +218,9 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 		keep     bool // Hold for extra examination after
 	}{
 		"Dockerfile":                                              {desc: "Dockerfile"},
-		"root/opt/scf/share/doc/tor/LICENSE":                      {desc: "release license file"},
-		"root/opt/scf/run.sh":                                     {desc: "run script"},
-		"root/opt/scf/startup/myrole.sh":                          {desc: "role specific startup script"},
+		"root/opt/fissile/share/doc/tor/LICENSE":                  {desc: "release license file"},
+		"root/opt/fissile/run.sh":                                 {desc: "run script"},
+		"root/opt/fissile/startup/myrole.sh":                      {desc: "role specific startup script"},
 		"root/var/vcap/jobs-src/tor/monit":                        {desc: "job monit file"},
 		"root/var/vcap/jobs-src/tor/templates/bin/monit_debugger": {desc: "job template file"},
 		"root/var/vcap/jobs-src/tor/config_spec.json":             {desc: "tor config spec", keep: true},

--- a/cmd/build-images.go
+++ b/cmd/build-images.go
@@ -33,7 +33,7 @@ directory structure contains jobs, packages and all other necessary scripts and
 templates.
 
 The images will have a 'role' label useful for filtering.
-The entrypoint for each image is ` + "`/opt/scf/run.sh`" + `.
+The entrypoint for each image is ` + "`/opt/fissile/run.sh`" + `.
 
 The images will be tagged: ` + "`<repository>-<role_name>:<SIGNATURE>`" + `.
 The SIGNATURE is based on the hashes of all jobs and packages that are included in

--- a/scripts/dockerfiles/Dockerfile-role
+++ b/scripts/dockerfiles/Dockerfile-role
@@ -8,5 +8,5 @@ LABEL "role"="{{ .role.Name }}"
 
 ADD root /
 
-RUN chmod +x /opt/scf/run.sh
-ENTRYPOINT ["/usr/bin/dumb-init", "/opt/scf/run.sh"]
+RUN chmod +x /opt/fissile/run.sh
+ENTRYPOINT ["/usr/bin/dumb-init", "/opt/fissile/run.sh"]

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -88,16 +88,16 @@ echo "${KUBE_COMPONENT_INDEX}" > /var/vcap/instance/id
 
 # Run custom environment scripts (that are sourced)
 {{ range $script := .role.EnvironScripts }}
-    source {{ if not (is_abs $script) }}/opt/scf/startup/{{ end }}{{ $script }}
+    source {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
 {{ end }}
 # Run custom role scripts
 {{ range $script := .role.Scripts}}
-    bash {{ if not (is_abs $script) }}/opt/scf/startup/{{ end }}{{ $script }}
+    bash {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
 {{ end }}
 
 configgin \
-	--jobs /opt/scf/job_config.json \
-	--env2conf /opt/scf/env2conf.yml
+	--jobs /opt/fissile/job_config.json \
+	--env2conf /opt/fissile/env2conf.yml
 
 if [ -e /etc/monitrc ]
 then
@@ -128,8 +128,8 @@ fi
 # Run any custom scripts other than pre-start
 {{ range $script := .role.PostConfigScripts}}
 {{ if not (is_pre_start $script) }}
-    echo bash {{ if not (is_abs $script) }}/opt/scf/startup/{{ end }}{{ $script }}
-    bash {{ if not (is_abs $script) }}/opt/scf/startup/{{ end }}{{ $script }}
+    echo bash {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
+    bash {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
 {{ end }}
 {{ end }}
 

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -13,18 +13,6 @@ EOL
 exit 0
 fi
 
-# Compatibility code for use with older stemcells. Move all files
-# provided in the old location to the new. And fix the references
-# they have.
-
-if [ -d /opt/hcf ] ; then
-    mkdir -p /opt/scf
-    mv       /opt/hcf/* /opt/scf/
-    rmdir    /opt/hcf
-    sed < /opt/scf/monitrc.erb > $$ -e 's|/hcf|/scf|'
-    mv $$ /opt/scf/monitrc.erb
-fi
-
 # Make BOSH installed binaries available
 export PATH=/var/vcap/bosh/bin:$PATH
 


### PR DESCRIPTION
Ref: https://trello.com/c/ZNBu0nTv/4-5-remove-remaining-references-to-hcf-hcp
See commit e937051cf5 where this code was added (June 27, 2017).

:construction: Wait with merge, this has lots of related changes, see ticket.
:stop_sign: Do not merge until after the stemcells __in use__ are purged of the `opt/hcf` references.
