### PR TITLE
Use routing table to determine container IP address

### DIFF
--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -71,7 +71,7 @@ fi
 
 # Note, any changes to this list of variables have to be replicated in
 # --> model/mustache.go, func builtins
-export IP_ADDRESS=$(/bin/hostname -i | awk '{print $1}')
+export IP_ADDRESS=$(ip route | grep -v ^default | awk '{print $NF;exit}')
 export DNS_RECORD_NAME=$(/bin/hostname)
 export KUBE_COMPONENT_INDEX="${HOSTNAME##*-}"
 if test -n "${KUBE_COMPONENT_INDEX//[0-9]/}" ; then


### PR DESCRIPTION
Using `hostname -i` relies on DNS, which doesn't seem to work reliably on all configurations:

```
routing-api/0:/# hostname -i
hostname: Name or service not known
```