### PR TITLE
S4mXqwBB Append Release.Revision to Job names

### DIFF
--- a/kube/job.go
+++ b/kube/job.go
@@ -24,14 +24,16 @@ func NewJob(role *model.Role, settings ExportSettings) (helm.Node, error) {
 		return nil, fmt.Errorf("Role %s has unexpected flight stage %s", role.Name, role.Run.FlightStage)
 	}
 
+	name := role.Name
 	apiVersion := "extensions/v1beta1"
 	if settings.CreateHelmChart {
+		name += "-{{ .Release.Revision }}"
 		// Job objects become a regular feature in kube 1.6
 		apiVersion = fmt.Sprintf("{{ if %s -}} batch/v1 {{- else -}} %s {{- end }}", minKubeVersion(1, 6), apiVersion)
 	}
 
 	metadata := helm.NewMapping()
-	metadata.Add("name", role.Name)
+	metadata.Add("name", name)
 	if role.Run.ObjectAnnotations != nil {
 		metadata.Add("annotations", *role.Run.ObjectAnnotations)
 	}

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -244,6 +244,10 @@ func getEnvVars(role *model.Role, defaults map[string]string, secrets SecretRefM
 		env = append(env, helm.NewMapping("name", config.Name, "value", stringifiedValue))
 	}
 
+	if settings.CreateHelmChart {
+		env = append(env, helm.NewMapping("name", "RELEASE_REVISION", "value", "{{ .Release.Revision | quote }}"))
+	}
+
 	fieldRef := helm.NewMapping("fieldPath", "metadata.namespace")
 
 	envVar := helm.NewMapping("name", "KUBERNETES_NAMESPACE")

--- a/kube/secret.go
+++ b/kube/secret.go
@@ -66,6 +66,9 @@ func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, Secre
 	secretName := "secret"
 	if settings.UseSecretsGenerator {
 		secretName = "secret-update"
+		if settings.CreateHelmChart {
+			secretName = "secret-update-{{ .Release.Revision }}"
+		}
 	}
 	secret := newKubeConfig("v1", "Secret", secretName)
 	secret.Add("data", data)


### PR DESCRIPTION
We want jobs to run again during `helm upgrade`. This means we have to delete the job before creating it again, which helm doesn't support, except for helm "hooks".  Using a revision suffix creates a new Job that will still run while the old one can be removed because it is no longer included in the chart.

Also create a `RELEASE_REVISION` environment variable and append the revision to the `secret-update` name so the secrets generator can access the correct generation of this data.