### PR TITLE
j8BtwZ51 Define "environment"-supplied variables if they have a default value

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -227,7 +227,7 @@ func getEnvVars(role *model.Role, defaults map[string]string, secrets SecretRefM
 		}
 
 		var stringifiedValue string
-		if settings.CreateHelmChart {
+		if settings.CreateHelmChart && config.Type == model.CVTypeUser {
 			required := ""
 			if config.Required {
 				required = fmt.Sprintf(`required "%s configuration missing" `, config.Name)

--- a/model/mustache.go
+++ b/model/mustache.go
@@ -55,6 +55,8 @@ func (r *Role) GetVariablesForRole() (ConfigurationVariableSlice, error) {
 					if confVar, ok := configsDictionary[envVar]; ok {
 						if confVar.Type == CVTypeUser {
 							configs[confVar.Name] = confVar
+						} else if confVar.Type == CVTypeEnv && confVar.Default != "" {
+							configs[confVar.Name] = confVar
 						}
 					}
 				}


### PR DESCRIPTION
So far the assumption is that config variables of the "environment" type will be provided by the "system", e.g. via `run.sh`. But there may also be settings that are build-time choices (so users can't override), but still need to be available at runtime as env vars.

This will be used by SCF to configure the `SUSE_STACK` value, but will also create a `KUBE_AZ` variable, which currently is only promised but never instantiated.