### PR TITLE
Show a more sensible error for a missing base image

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -648,7 +648,7 @@ func (f *Fissile) ListRoleImages(registry, organization, repository, roleManifes
 
 		image, err := dockerManager.FindImage(imageName)
 
-		if err == docker.ErrImageNotFound {
+		if _, ok := err.(docker.ErrImageNotFound); ok {
 			continue
 		} else if err != nil {
 			return fmt.Errorf("Error looking up image: %s", err.Error())

--- a/builder/packages_image.go
+++ b/builder/packages_image.go
@@ -48,6 +48,9 @@ func NewPackagesImageBuilder(repository, stemcellImageName, stemcellImageID, com
 
 		stemcellImage, err := imageManager.FindImage(stemcellImageName)
 		if err != nil {
+			if _, ok := err.(docker.ErrImageNotFound); ok {
+				return nil, fmt.Errorf("Stemcell %s", err.Error())
+			}
 			return nil, err
 		}
 

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -61,7 +61,8 @@ func TestFindImageNotOK(t *testing.T) {
 	_, err = dockerManager.FindImage(name)
 
 	assert.Error(err)
-	assert.Equal(ErrImageNotFound, err)
+	_, ok := err.(ErrImageNotFound)
+	assert.True(ok)
 }
 
 func TestHasImageOK(t *testing.T) {


### PR DESCRIPTION
https://trello.com/c/cukB9mOo/308-fissiles-error-message-is-unhelpful-when-the-base-image-it-uses-for-building-images-is-unavailable
