### PR TITLE
Add auth-type option

### DIFF
--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -14,6 +14,7 @@ var (
 	flagBuildHelmUseMemoryLimits     bool
 	flagBuildHelmTagExtra            string
 	flagBuildHelmUseSecretsGenerator bool
+	flagBuildHelmAuthType            string
 )
 
 // buildHelmCmd represents the helm command
@@ -29,6 +30,7 @@ var buildHelmCmd = &cobra.Command{
 		flagBuildHelmTagExtra = buildHelmViper.GetString("tag-extra")
 		flagBuildHelmUseSecretsGenerator = buildHelmViper.GetBool("use-secrets-generator")
 		flagBuildOutputGraph = buildViper.GetString("output-graph")
+		flagBuildHelmAuthType = buildViper.GetString("auth-type")
 
 		err := fissile.LoadReleases(
 			flagRelease,
@@ -61,6 +63,7 @@ var buildHelmCmd = &cobra.Command{
 			CreateHelmChart:     true,
 			UseSecretsGenerator: flagBuildHelmUseSecretsGenerator,
 			TagExtra:            flagBuildHelmTagExtra,
+			AuthType:            flagBuildHelmAuthType,
 		}
 
 		if flagBuildOutputGraph != "" {
@@ -116,6 +119,13 @@ func init() {
 		"",
 		false,
 		"Passwords will not be set by helm templates, but all secrets with a generator will be set/updated at runtime via a generator job like https://github.com/SUSE/scf-seret-generator",
+	)
+
+	buildHelmCmd.PersistentFlags().StringP(
+		"auth-type",
+		"",
+		"",
+		"Sets the Kubernetes auth type",
 	)
 
 	buildHelmViper.BindPFlags(buildHelmCmd.PersistentFlags())

--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -30,7 +30,7 @@ var buildHelmCmd = &cobra.Command{
 		flagBuildHelmTagExtra = buildHelmViper.GetString("tag-extra")
 		flagBuildHelmUseSecretsGenerator = buildHelmViper.GetBool("use-secrets-generator")
 		flagBuildOutputGraph = buildViper.GetString("output-graph")
-		flagBuildHelmAuthType = buildViper.GetString("auth-type")
+		flagBuildHelmAuthType = buildHelmViper.GetString("auth-type")
 
 		err := fissile.LoadReleases(
 			flagRelease,

--- a/kube/export_settings.go
+++ b/kube/export_settings.go
@@ -21,4 +21,5 @@ type ExportSettings struct {
 	Secrets             SecretRefMap
 	CreateHelmChart     bool
 	UseSecretsGenerator bool
+	AuthType            string
 }

--- a/kube/values.go
+++ b/kube/values.go
@@ -94,7 +94,12 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	kube.Add("storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"))
 	kube.Add("registry", registryInfo)
 	kube.Add("organization", settings.Organization)
-	kube.Add("auth", nil)
+
+	if settings.AuthType == "" {
+		kube.Add("auth", nil)
+	} else {
+		kube.Add("auth", settings.AuthType)
+	}
 
 	values := helm.NewMapping()
 	values.Add("env", env)

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -74,7 +74,7 @@ func TestMakeValues(t *testing.T) {
 
 		auth := node.Get("kube").Get("auth")
 
-		assert.Equal(auth.String(), "~")
+		assert.Equal(auth.String(), "~", "Default value should be nil")
 	})
 
 	t.Run("Check Custom Auth", func(t *testing.T) {

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -1,0 +1,96 @@
+package kube
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/SUSE/fissile/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeValues(t *testing.T) {
+	t.Parallel()
+
+	assert := assert.New(t)
+	outDir, err := ioutil.TempDir("", "fissile-generate-auth-")
+	require.NoError(t, err)
+	defer os.RemoveAll(outDir)
+
+	t.Run("Check Default Registry", func(t *testing.T) {
+		settings := ExportSettings{
+			OutputDir: outDir,
+			RoleManifest: &model.RoleManifest{Roles: model.Roles{},
+				Configuration: &model.Configuration{},
+			},
+		}
+
+		node, err := MakeValues(settings)
+
+		assert.NotNil(node)
+		assert.NoError(err)
+
+		registry := node.Get("kube").Get("registry").Get("hostname")
+
+		assert.Equal(registry.String(), "docker.io")
+	})
+
+	t.Run("Check Custom Registry", func(t *testing.T) {
+		settings := ExportSettings{
+			OutputDir: outDir,
+			RoleManifest: &model.RoleManifest{Roles: model.Roles{},
+				Configuration: &model.Configuration{},
+			},
+		}
+
+		settings.Registry = "example.com"
+
+		node, err := MakeValues(settings)
+
+		assert.NotNil(node)
+		assert.NoError(err)
+
+		registry := node.Get("kube").Get("registry").Get("hostname")
+
+		assert.Equal(registry.String(), "example.com")
+	})
+
+	t.Run("Check Default Auth", func(t *testing.T) {
+		settings := ExportSettings{
+			OutputDir: outDir,
+			RoleManifest: &model.RoleManifest{Roles: model.Roles{},
+				Configuration: &model.Configuration{},
+			},
+		}
+
+		node, err := MakeValues(settings)
+
+		assert.NotNil(node)
+		assert.NoError(err)
+
+		auth := node.Get("kube").Get("auth")
+
+		assert.Equal(auth.String(), "~")
+	})
+
+	t.Run("Check Custom Auth", func(t *testing.T) {
+		settings := ExportSettings{
+			OutputDir: outDir,
+			RoleManifest: &model.RoleManifest{Roles: model.Roles{},
+				Configuration: &model.Configuration{},
+			},
+		}
+
+		settings.AuthType = "rbac"
+
+		node, err := MakeValues(settings)
+
+		assert.NotNil(node)
+		assert.NoError(err)
+
+		auth := node.Get("kube").Get("auth")
+
+		assert.Equal(auth.String(), "rbac")
+	})
+}

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -19,6 +19,7 @@ func TestMakeValues(t *testing.T) {
 	defer os.RemoveAll(outDir)
 
 	t.Run("Check Default Registry", func(t *testing.T) {
+		t.Parallel()
 		settings := ExportSettings{
 			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{Roles: model.Roles{},
@@ -37,6 +38,7 @@ func TestMakeValues(t *testing.T) {
 	})
 
 	t.Run("Check Custom Registry", func(t *testing.T) {
+		t.Parallel()
 		settings := ExportSettings{
 			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{Roles: model.Roles{},
@@ -57,6 +59,7 @@ func TestMakeValues(t *testing.T) {
 	})
 
 	t.Run("Check Default Auth", func(t *testing.T) {
+		t.Parallel()
 		settings := ExportSettings{
 			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{Roles: model.Roles{},
@@ -75,6 +78,7 @@ func TestMakeValues(t *testing.T) {
 	})
 
 	t.Run("Check Custom Auth", func(t *testing.T) {
+		t.Parallel()
 		settings := ExportSettings{
 			OutputDir: outDir,
 			RoleManifest: &model.RoleManifest{Roles: model.Roles{},

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -86,7 +86,9 @@ func TestMakeValues(t *testing.T) {
 			},
 		}
 
-		settings.AuthType = "rbac"
+		authString := "foo"
+
+		settings.AuthType = authString
 
 		node, err := MakeValues(settings)
 
@@ -95,6 +97,6 @@ func TestMakeValues(t *testing.T) {
 
 		auth := node.Get("kube").Get("auth")
 
-		assert.Equal(auth.String(), "rbac")
+		assert.Equal(auth.String(), authString)
 	})
 }


### PR DESCRIPTION
Add a command line option to set the auth type in the generated
`values.yaml` file. The default remains `~`.