### PR TITLE
Validate previous_names section of config vars

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -69,6 +69,7 @@ configuration:
   - name: NATS_USER
     description: User name for NATS
     required: true
+    previous_names: [NATS_USR]
 ```
 
 Note that there are a few special variables that are automatically supplied to

--- a/model/roles.go
+++ b/model/roles.go
@@ -191,15 +191,16 @@ type Configuration struct {
 //    A public CV is used in templates
 //    An internal CV is not, consumed in a script instead.
 type ConfigurationVariable struct {
-	Name        string                          `yaml:"name"`
-	Default     interface{}                     `yaml:"default"`
-	Description string                          `yaml:"description"`
-	Example     string                          `yaml:"example"`
-	Generator   *ConfigurationVariableGenerator `yaml:"generator"`
-	Type        CVType                          `yaml:"type"`
-	Internal    bool                            `yaml:"internal,omitempty"`
-	Secret      bool                            `yaml:"secret,omitempty"`
-	Required    bool                            `yaml:"required,omitempty"`
+	Name          string                          `yaml:"name"`
+	PreviousNames []string                        `yaml:"previous_names"`
+	Default       interface{}                     `yaml:"default"`
+	Description   string                          `yaml:"description"`
+	Example       string                          `yaml:"example"`
+	Generator     *ConfigurationVariableGenerator `yaml:"generator"`
+	Type          CVType                          `yaml:"type"`
+	Internal      bool                            `yaml:"internal,omitempty"`
+	Secret        bool                            `yaml:"secret,omitempty"`
+	Required      bool                            `yaml:"required,omitempty"`
 }
 
 // Value fetches the value of config variable
@@ -392,6 +393,7 @@ func LoadRoleManifest(manifestFilePath string, releases []*Release, grapher util
 		allErrs = append(allErrs, roleManifest.resolveLinks()...)
 		allErrs = append(allErrs, validateVariableType(roleManifest.Configuration.Variables)...)
 		allErrs = append(allErrs, validateVariableSorting(roleManifest.Configuration.Variables)...)
+		allErrs = append(allErrs, validateVariablePreviousNames(roleManifest.Configuration.Variables)...)
 		allErrs = append(allErrs, validateVariableUsage(&roleManifest)...)
 		allErrs = append(allErrs, validateTemplateUsage(&roleManifest)...)
 		allErrs = append(allErrs, validateNonTemplates(&roleManifest)...)
@@ -920,6 +922,33 @@ func validateVariableSorting(variables ConfigurationVariableSlice) validation.Er
 				previousName, "Appears more than once"))
 		}
 		previousName = cv.Name
+	}
+
+	return allErrs
+}
+
+// validateVariablePreviousNames tests whether PreviousNames of a variable are used either
+// by as a Name or a PreviousName of another variable.
+func validateVariablePreviousNames(variables ConfigurationVariableSlice) validation.ErrorList {
+	allErrs := validation.ErrorList{}
+
+	for _, cvOuter := range variables {
+		for _, previousOuter := range cvOuter.PreviousNames {
+			for _, cvInner := range variables {
+				if previousOuter == cvInner.Name {
+					allErrs = append(allErrs, validation.Invalid("configuration.variables",
+						cvOuter.Name,
+						fmt.Sprintf("Previous name '%s' also exist as a new variable", cvInner.Name)))
+				}
+				for _, previousInner := range cvInner.PreviousNames {
+					if cvOuter.Name != cvInner.Name && previousOuter == previousInner {
+						allErrs = append(allErrs, validation.Invalid("configuration.variables",
+							cvOuter.Name,
+							fmt.Sprintf("Previous name '%s' also claimed by '%s'", previousOuter, cvInner.Name)))
+					}
+				}
+			}
+		}
 	}
 
 	return allErrs

--- a/model/roles.go
+++ b/model/roles.go
@@ -915,6 +915,9 @@ func validateVariableSorting(variables ConfigurationVariableSlice) validation.Er
 			allErrs = append(allErrs, validation.Invalid("configuration.variables",
 				previousName,
 				fmt.Sprintf("Does not sort before '%s'", cv.Name)))
+		} else if cv.Name == previousName {
+			allErrs = append(allErrs, validation.Invalid("configuration.variables",
+				previousName, "Appears more than once"))
 		}
 		previousName = cv.Name
 	}

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -303,6 +303,27 @@ func TestLoadRoleManifestVariablesSortedError(t *testing.T) {
 	assert.Nil(roleManifest)
 }
 
+func TestLoadRoleManifestVariablesPreviousNamesError(t *testing.T) {
+	assert := assert.New(t)
+
+	workDir, err := os.Getwd()
+	assert.NoError(err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(err)
+
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/variables-with-dup-prev-names.yml")
+	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
+
+	assert.Contains(err.Error(), `configuration.variables: Invalid value: "FOO": Previous name 'BAR' also exist as a new variable`)
+	assert.Contains(err.Error(), `configuration.variables: Invalid value: "FOO": Previous name 'BAZ' also claimed by 'QUX'`)
+	assert.Contains(err.Error(), `configuration.variables: Invalid value: "QUX": Previous name 'BAZ' also claimed by 'FOO'`)
+	// Note how this ignores other errors possibly present in the manifest and releases.
+	assert.Nil(roleManifest)
+}
+
 func TestLoadRoleManifestVariablesNotUsed(t *testing.T) {
 	assert := assert.New(t)
 

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -298,6 +298,7 @@ func TestLoadRoleManifestVariablesSortedError(t *testing.T) {
 
 	assert.Contains(err.Error(), `configuration.variables: Invalid value: "FOO": Does not sort before 'BAR'`)
 	assert.Contains(err.Error(), `configuration.variables: Invalid value: "PELERINUL": Does not sort before 'ALPHA'`)
+	assert.Contains(err.Error(), `configuration.variables: Invalid value: "PELERINUL": Appears more than once`)
 	// Note how this ignores other errors possibly present in the manifest and releases.
 	assert.Nil(roleManifest)
 }

--- a/test-assets/role-manifests/variables-badly-sorted.yml
+++ b/test-assets/role-manifests/variables-badly-sorted.yml
@@ -27,6 +27,7 @@ configuration:
   - name: FOO
   - name: BAR
   - name: PELERINUL
+  - name: PELERINUL
   - name: ALPHA
   templates:
     properties.tor.hostname: '((FOO))((ALPHA))'

--- a/test-assets/role-manifests/variables-with-dup-prev-names.yml
+++ b/test-assets/role-manifests/variables-with-dup-prev-names.yml
@@ -1,0 +1,28 @@
+---
+roles:
+- name: myrole
+  environment_scripts:
+  - environ.sh
+  - /environ/script/with/absolute/path.sh
+  scripts:
+  - myrole.sh
+  - /script/with/absolute/path.sh
+  post_config_scripts:
+  - post_config_script.sh
+  - /var/vcap/jobs/myrole/pre-start
+  run:
+    foo: x
+  jobs:
+  - name: new_hostname
+    release_name: tor
+  - name: tor
+    release_name: tor
+configuration:
+  variables:
+  - name: BAR
+  - name: FOO
+    previous_names: [BAR, BAZ]
+  - name: QUX
+    previous_names: [BAZ]
+  templates:
+    properties.tor.hostname: '((FOO))((BAR))((QUX))'


### PR DESCRIPTION
Throw an error when
- a previous name is introduced again
- two previous names of different variables have the same name