### PR TITLE
Handle indexed tag

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -1072,7 +1072,7 @@ func (f *Fissile) generateKubeRoles(settings kube.ExportSettings) error {
 			enc := helm.NewEncoder(outputFile)
 
 			needsStorage := len(role.Run.PersistentVolumes) != 0 || len(role.Run.SharedVolumes) != 0
-			if role.HasTag("clustered") || needsStorage {
+			if role.HasTag("clustered") || role.HasTag("indexed") || needsStorage {
 				statefulSet, deps, err := kube.NewStatefulSet(role, settings, f)
 				if err != nil {
 					return err

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -15,7 +15,7 @@ func NewDeployment(role *model.Role, settings ExportSettings, grapher util.Model
 		return nil, nil, err
 	}
 
-	svc, err := NewClusterIPServiceList(role, false, settings)
+	svc, err := NewClusterIPServiceList(role, false, true, settings)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kube/service.go
+++ b/kube/service.go
@@ -23,16 +23,19 @@ func NewClusterIPServiceList(role *model.Role, headless bool, settings ExportSet
 		}
 	}
 
-	// Create private service
-	svc, err := NewClusterIPService(role, false, false, settings)
-	if err != nil {
-		return nil, err
+	if role.HasTag("indexed") {
+		// Create private service
+		svc, err := NewClusterIPService(role, false, false, settings)
+		if err != nil {
+			return nil, err
+		}
+		if svc != nil {
+			items = append(items, svc)
+		}
 	}
-	if svc != nil {
-		items = append(items, svc)
-	}
+
 	// Create public service
-	svc, err = NewClusterIPService(role, false, true, settings)
+	svc, err := NewClusterIPService(role, false, true, settings)
 	if err != nil {
 		return nil, err
 	}

--- a/kube/service.go
+++ b/kube/service.go
@@ -9,7 +9,7 @@ import (
 )
 
 // NewClusterIPServiceList creates a list of ClusterIP services
-func NewClusterIPServiceList(role *model.Role, headless bool, settings ExportSettings) (helm.Node, error) {
+func NewClusterIPServiceList(role *model.Role, headless, private bool, settings ExportSettings) (helm.Node, error) {
 	var items []helm.Node
 
 	if headless {
@@ -23,7 +23,7 @@ func NewClusterIPServiceList(role *model.Role, headless bool, settings ExportSet
 		}
 	}
 
-	if role.HasTag("indexed") {
+	if private {
 		// Create private service
 		svc, err := NewClusterIPService(role, false, false, settings)
 		if err != nil {

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -21,7 +21,7 @@ func NewStatefulSet(role *model.Role, settings ExportSettings, grapher util.Mode
 		return nil, nil, err
 	}
 
-	svcList, err := NewClusterIPServiceList(role, true, settings)
+	svcList, err := NewClusterIPServiceList(role, true, !role.HasTag("clustered"), settings)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR changes how clustered roles work: there is no service generated any more, and the corresponding configgin changes handle this by getting the instance info from the StatefulSet.

https://github.com/SUSE/configgin/pull/64/files

The old style of services will be called `indexed` in our role manifest. Currently, only doppler will get the `clustered` tag, but I expect others will be updated as well.

The reason for removing services is it ensures we aren't accidentally using the load balanced hostname (e.g. `doppler.svc.cf.cluster.local`), instead we use a list of specific hostnames.