### PR TITLE
Run BOSH drain scripts

### DIFF
--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -232,10 +232,6 @@ func (r *RoleImageBuilder) NewDockerPopulator(role *model.Role, baseImageName st
 	}
 }
 
-func isPreStart(s string) bool {
-	return strings.HasSuffix(s, "/bin/pre-start")
-}
-
 func (r *RoleImageBuilder) generateRunScript(role *model.Role) ([]byte, error) {
 	asset, err := dockerfiles.Asset("run.sh")
 	if err != nil {
@@ -244,8 +240,7 @@ func (r *RoleImageBuilder) generateRunScript(role *model.Role) ([]byte, error) {
 
 	runScriptTemplate := template.New("role-runscript")
 	runScriptTemplate.Funcs(template.FuncMap{
-		"is_abs":       filepath.IsAbs,
-		"is_pre_start": isPreStart,
+		"is_abs": filepath.IsAbs,
 	})
 	context := map[string]interface{}{
 		"role": role,

--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -240,7 +240,12 @@ func (r *RoleImageBuilder) generateRunScript(role *model.Role) ([]byte, error) {
 
 	runScriptTemplate := template.New("role-runscript")
 	runScriptTemplate.Funcs(template.FuncMap{
-		"is_abs": filepath.IsAbs,
+		"script_path": func(path string) string {
+			if filepath.IsAbs(path) {
+				return path
+			}
+			return filepath.Join("/opt/fissile/startup/", path)
+		},
 	})
 	context := map[string]interface{}{
 		"role": role,

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -105,26 +105,34 @@ func TestGenerateRoleImageRunScript(t *testing.T) {
 	roleImageBuilder, err := NewRoleImageBuilder("foo", compiledPackagesDir, targetPath, lightOpinionsPath, darkOpinionsPath, "", "deadbeef", "6.28.30", ui, nil)
 	assert.NoError(err)
 
-	runScriptContents, err := roleImageBuilder.generateRunScript(roleManifest.Roles[0])
-	assert.NoError(err)
-	assert.Contains(string(runScriptContents), "source /opt/fissile/startup/environ.sh")
-	assert.Contains(string(runScriptContents), "source /environ/script/with/absolute/path.sh")
-	assert.NotContains(string(runScriptContents), "/opt/fissile/startup/environ/script/with/absolute/path.sh")
-	assert.NotContains(string(runScriptContents), "/opt/fissile/startup//environ/script/with/absolute/path.sh")
-	assert.Contains(string(runScriptContents), "bash /opt/fissile/startup/myrole.sh")
-	assert.Contains(string(runScriptContents), "bash /script/with/absolute/path.sh")
-	assert.NotContains(string(runScriptContents), "/opt/fissile/startup/script/with/absolute/path.sh")
-	assert.NotContains(string(runScriptContents), "/opt/fissile/startup//script/with/absolute/path.sh")
-	assert.Contains(string(runScriptContents), "bash /opt/fissile/startup/post_config_script.sh")
-	assert.Contains(string(runScriptContents), "bash /var/vcap/jobs/myrole/pre-start")
-	assert.NotContains(string(runScriptContents), "/opt/fissile/startup/var/vcap/jobs/myrole/pre-start")
-	assert.NotContains(string(runScriptContents), "/opt/fissile//startup/var/vcap/jobs/myrole/pre-start")
-	assert.Contains(string(runScriptContents), "monit -vI &")
+	runScriptContents, err := roleImageBuilder.generateRunScript(roleManifest.Roles[0], "run.sh")
+	if assert.NoError(err) {
+		assert.Contains(string(runScriptContents), "source /opt/fissile/startup/environ.sh")
+		assert.Contains(string(runScriptContents), "source /environ/script/with/absolute/path.sh")
+		assert.NotContains(string(runScriptContents), "/opt/fissile/startup/environ/script/with/absolute/path.sh")
+		assert.NotContains(string(runScriptContents), "/opt/fissile/startup//environ/script/with/absolute/path.sh")
+		assert.Contains(string(runScriptContents), "bash /opt/fissile/startup/myrole.sh")
+		assert.Contains(string(runScriptContents), "bash /script/with/absolute/path.sh")
+		assert.NotContains(string(runScriptContents), "/opt/fissile/startup/script/with/absolute/path.sh")
+		assert.NotContains(string(runScriptContents), "/opt/fissile/startup//script/with/absolute/path.sh")
+		assert.Contains(string(runScriptContents), "bash /opt/fissile/startup/post_config_script.sh")
+		assert.Contains(string(runScriptContents), "bash /var/vcap/jobs/myrole/pre-start")
+		assert.NotContains(string(runScriptContents), "/opt/fissile/startup/var/vcap/jobs/myrole/pre-start")
+		assert.NotContains(string(runScriptContents), "/opt/fissile//startup/var/vcap/jobs/myrole/pre-start")
+		assert.Contains(string(runScriptContents), "monit -vI &")
+	}
 
-	runScriptContents, err = roleImageBuilder.generateRunScript(roleManifest.Roles[1])
-	assert.NoError(err)
-	assert.NotContains(string(runScriptContents), "monit -vI")
-	assert.Contains(string(runScriptContents), "/var/vcap/jobs/tor/bin/run")
+	runScriptContents, err = roleImageBuilder.generateRunScript(roleManifest.Roles[1], "run.sh")
+	if assert.NoError(err) {
+		assert.NotContains(string(runScriptContents), "monit -vI")
+		assert.Contains(string(runScriptContents), "/var/vcap/jobs/tor/bin/run")
+	}
+
+	preStopScriptContents, err := roleImageBuilder.generateRunScript(roleManifest.Roles[0], "pre-stop.sh")
+	if assert.NoError(err) {
+		assert.Contains(string(preStopScriptContents), "drain_job new_hostname")
+		assert.Contains(string(preStopScriptContents), "drain_job tor")
+	}
 }
 
 func TestGenerateRoleImageJobsConfig(t *testing.T) {

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -86,6 +86,9 @@ func NewPodTemplate(role *model.Role, settings ExportSettings, grapher util.Mode
 		}
 		spec.Add("serviceAccountName", role.Run.ServiceAccount, block)
 	}
+	// BOSH can potentially have an infinite termination grace period; we don't
+	// really trust that, so we'll just go with ten minutes and hope it's enough
+	spec.Add("terminationGracePeriodSeconds", 600)
 	spec.Sort()
 
 	podTemplate := helm.NewMapping()

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -64,6 +64,11 @@ func NewPodTemplate(role *model.Role, settings ExportSettings, grapher util.Mode
 	container.Add("securityContext", securityContext)
 	container.Add("livenessProbe", livenessProbe)
 	container.Add("readinessProbe", readinessProbe)
+	container.Add("lifecycle",
+		helm.NewMapping("preStop",
+			helm.NewMapping("exec",
+				helm.NewMapping("command",
+					[]string{"/opt/fissile/pre-stop.sh"}))))
 	container.Sort()
 
 	imagePullSecrets := helm.NewMapping("name", "registry-credentials")

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -859,6 +859,7 @@ func TestPodPreFlight(t *testing.T) {
 			-
 				name: pre-role
 			restartPolicy: OnFailure
+			terminationGracePeriodSeconds: 600
 	`, "\t", "    ", -1)
 	if !assert.NoError(yaml.Unmarshal([]byte(expectedYAML), &expected)) {
 		return

--- a/scripts/dockerfiles/Dockerfile-role
+++ b/scripts/dockerfiles/Dockerfile-role
@@ -8,5 +8,5 @@ LABEL "role"="{{ .role.Name }}"
 
 ADD root /
 
-RUN chmod +x /opt/fissile/run.sh
+RUN chmod +x /opt/fissile/run.sh /opt/fissile/pre-stop.sh
 ENTRYPOINT ["/usr/bin/dumb-init", "/opt/fissile/run.sh"]

--- a/scripts/dockerfiles/pre-stop.sh
+++ b/scripts/dockerfiles/pre-stop.sh
@@ -11,49 +11,51 @@
 exec 1> /proc/1/fd/1
 exec 2> /proc/1/fd/2
 
-set -o errexit
+if test -n "${1:-}" ; then
+    # This script is being run from itself, to spawn one drain script
+    # This is necesary to get the parallel execution
+    if ! [ -x "/var/vcap/jobs/$1/bin/drain" ] ; then
+        exit 0
+    fi
+    printf "Running drain script for %s\n" "$1" >&2
 
+    while true ; do
+        # Tee the output to main container logs too, so we can see issues
+        output="$("/var/vcap/jobs/$1/bin/drain" > >(tee /proc/1/fd/1))"
+        result="$?"
+        if test "${result}" -ne 0 ; then
+            # drain script exited with non-zero; abort with that code
+            printf "Pre-stop script for %s terminated with %s\n" "$1" "${result}" >&2
+            exit "${result}"
+        fi
+        # stdout is expected to be a number, possibly followed by a new line
+        # If it is >= 0, wait that many seconds and go to next script
+        # If it is < 0, sleep for that many seconds, then retry
+        if test "${output}" -lt 0 ; then
+            sleep $(( 0 - output ))
+        else
+            sleep "${output}"
+            break
+        fi
+    done
+    exit 0
+fi
+
+set -o errexit
 echo "Running pre-stop script..."
 
 {{ if ne .role.Type "bosh-task" }}
     processes=($(/var/vcap/bosh/bin/monit summary | awk '$1 == "Process" { print $2 }' | tr -d "'"))
 
     # Lifecycle: Stop: 1. `monit unmonitor` is called for each process
-    echo "${processes[@]}" | xargs -n1 /var/vcap/bosh/bin/monit unmonitor
+    echo "${processes[@]}" | xargs --max-args=1 /var/vcap/bosh/bin/monit unmonitor
 
     # Lifecycle: Stop: 2. Drain scripts
-    drain_job() {
-        if ! [ -x "/var/vcap/jobs/$1/bin/drain" ] ; then
-            return 0
-        fi
-        printf "Running drain script for %s\n" "$1" >&2
-
-        while true ; do
-            # Tee the output to main container logs too, so we can see issues
-            output="$("/var/vcap/jobs/$1/bin/drain" > >(tee /proc/1/fd/1))"
-            result="$?"
-            if test "${result}" -ne 0 ; then
-                # drain script exited with non-zero; abort with that code
-                printf "Pre-stop script for %s terminated with %s\n" "$1" "${result}" >&2
-                exit "${result}"
-            fi
-            # stdout is expected to be a number, possibly followed by a new line
-            # If it is >= 0, wait that many seconds and go to next script
-            # If it is < 0, sleep for that many seconds, then retry
-            if test "${output}" -lt 0 ; then
-                sleep $(( 0 - output ))
-            else
-                sleep "${output}"
-                break
-            fi
-        done
-    }
-    {{ range $job := .role.RoleJobs }}
-        drain_job {{ $job.Name }}
-    {{ end }}
+    # We exec ourselves via xargs to run things in parallel and collect exit status
+    echo {{ range .role.RoleJobs }} {{ .Name }} {{ end }} | xargs --max-args=1 --max-procs=0 "${0}"
 
     # Lifecycle: Stop: 3. `monit stop` is called for each process
-    echo "${processes[@]}" | xargs -n1 /var/vcap/bosh/bin/monit stop
+    echo "${processes[@]}" | xargs --max-args=1 /var/vcap/bosh/bin/monit stop
 {{ end }}
 
 echo "Pre-stop: All scripts completed successfully" >&2

--- a/scripts/dockerfiles/pre-stop.sh
+++ b/scripts/dockerfiles/pre-stop.sh
@@ -1,0 +1,60 @@
+#! /bin/bash
+
+# This script is executed as the Kubernetes pre-stop hook, which will in turn
+# excute the BOSH drain scripts
+
+# See https://bosh.io/docs/job-lifecycle.html#stop
+# https://bosh.io/docs/drain.html
+
+# Pre-Stop scripts don't have the normal stdout / stderr
+# Redirect everything to the ones that pid 1 uses
+exec 1> /proc/1/fd/1
+exec 2> /proc/1/fd/2
+
+set -o errexit
+
+echo "Running pre-stop script..."
+
+{{ if ne .role.Type "bosh-task" }}
+    processes=($(/var/vcap/bosh/bin/monit summary | awk '$1 == "Process" { print $2 }' | tr -d "'"))
+
+    # Lifecycle: Stop: 1. `monit unmonitor` is called for each process
+    echo "${processes[@]}" | xargs -n1 /var/vcap/bosh/bin/monit unmonitor
+
+    # Lifecycle: Stop: 2. Drain scripts
+    drain_job() {
+        if ! [ -x "/var/vcap/jobs/$1/bin/drain" ] ; then
+            return 0
+        fi
+        printf "Running drain script for %s\n" "$1" >&2
+
+        while true ; do
+            # Tee the output to main container logs too, so we can see issues
+            output="$("/var/vcap/jobs/$1/bin/drain" > >(tee /proc/1/fd/1))"
+            result="$?"
+            if test "${result}" -ne 0 ; then
+                # drain script exited with non-zero; abort with that code
+                printf "Pre-stop script for %s terminated with %s\n" "$1" "${result}" >&2
+                exit "${result}"
+            fi
+            # stdout is expected to be a number, possibly followed by a new line
+            # If it is >= 0, wait that many seconds and go to next script
+            # If it is < 0, sleep for that many seconds, then retry
+            if test "${output}" -lt 0 ; then
+                sleep $(( 0 - output ))
+            else
+                sleep "${output}"
+                break
+            fi
+        done
+    }
+    {{ range $job := .role.RoleJobs }}
+        drain_job {{ $job.Name }}
+    {{ end }}
+
+    # Lifecycle: Stop: 3. `monit stop` is called for each process
+    echo "${processes[@]}" | xargs -n1 /var/vcap/bosh/bin/monit stop
+{{ end }}
+
+echo "Pre-stop: All scripts completed successfully" >&2
+exit 0

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -127,10 +127,8 @@ fi
 # Run custom post config role scripts
 # Run any custom scripts other than pre-start
 {{ range $script := .role.PostConfigScripts}}
-{{ if not (is_pre_start $script) }}
     echo bash {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
     bash {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
-{{ end }}
 {{ end }}
 
 # Run all the scripts called pre-start, but ensure consul_agent/bin/pre-start is run before others.

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -88,11 +88,11 @@ echo "${KUBE_COMPONENT_INDEX}" > /var/vcap/instance/id
 
 # Run custom environment scripts (that are sourced)
 {{ range $script := .role.EnvironScripts }}
-    source {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
+    source {{ script_path $script }}
 {{ end }}
 # Run custom role scripts
 {{ range $script := .role.Scripts}}
-    bash {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
+    bash {{ script_path $script }}
 {{ end }}
 
 configgin \
@@ -127,8 +127,8 @@ fi
 # Run custom post config role scripts
 # Run any custom scripts other than pre-start
 {{ range $script := .role.PostConfigScripts}}
-    echo bash {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
-    bash {{ if not (is_abs $script) }}/opt/fissile/startup/{{ end }}{{ $script }}
+    echo bash {{ script_path $script }}
+    bash {{ script_path $script }}
 {{ end }}
 
 # Run all the scripts called pre-start, but ensure consul_agent/bin/pre-start is run before others.


### PR DESCRIPTION
This adds a Kubernetes pre-stop script which implements the [BOSH job stop lifecycle](https://bosh.io/docs/job-lifecycle.html#stop), including [drain scripts](https://bosh.io/docs/drain.html).  Note that this doesn't extend the time out for shut down, so it may terminate prematurely (but at least it does _something_).

There were some cleanups to `run.sh` too because I thought that was where part of the logic was going to live (it ended up being a dead end).
