### PR TITLE
Adjust to changes in go-vet 1.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ endif
 
 .PHONY: all clean format lint vet bindata build test docker-deps reap dist
 
-all: clean format lint vet bindata docker-deps build test
+all: clean format lint bindata docker-deps build test vet
 
 clean:
 	${GIT_ROOT}/make/clean

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -297,6 +297,8 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 	}
 	// Synchronize with the gofunc to make sure it's done
 	<-latch
+	assert.NoError(asyncError)
+
 	for name, info := range expected {
 		assert.Equal(TypeMissing, info.typeflag, "File %s was not found", name)
 	}

--- a/make/bindata
+++ b/make/bindata
@@ -11,13 +11,6 @@ go-bindata -pkg=dockerfiles -o=./scripts/dockerfiles/dockerfiles.go \
            ./scripts/dockerfiles/*.sh \
            ./scripts/dockerfiles/Dockerfile-* \
 
-# Note. We are working around an issue with go-bindata here.
-# See
-#	 https://github.com/jteeuwen/go-bindata/issues/110
-#
-# Further see the code after 'exit' for the original commands to use
-# (again) after go-bindata is fixed.
-#
 # We have to use just the directory, i.e. "./scripts/compilation" to
 # get the correct asset names in the output. This forces us to ensure
 # that the .go files in that directory are not bundled into the

--- a/make/clean
+++ b/make/clean
@@ -6,6 +6,7 @@ GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 rm -rf ${GIT_ROOT}/build
 rm -f ${GIT_ROOT}/fissile
+rm -f ${GIT_ROOT}/docker/mock_dockerclient_generated.go
 rm -f ${GIT_ROOT}/scripts/compilation/compilation.go
 rm -f ${GIT_ROOT}/scripts/dockerfiles/dockerfiles.go
 rm -f ${GIT_ROOT}/scripts/templates/transformations.go


### PR DESCRIPTION
* The scripts/dockerfiles/dockerfiles.go file must exist (make bindata).
* The docker/mock_dockerclient_generated.go file must exist (make test).
* The asyncError variable in builder/role_images.go must be referenced.

This commit also removed an outdated comment from make/bindata.