### PR TITLE
Allow multiple IPs for external IP

### DIFF
--- a/kube/values.go
+++ b/kube/values.go
@@ -90,7 +90,7 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	registryInfo.Add("password", settings.Password)
 
 	kube := helm.NewMapping()
-	kube.Add("external_ip", "192.168.77.77")
+	kube.Add("external_ips", helm.NewList("192.168.77.77"))
 	kube.Add("storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"))
 	kube.Add("registry", registryInfo)
 	kube.Add("organization", settings.Organization)

--- a/kube/values.go
+++ b/kube/values.go
@@ -90,7 +90,7 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	registryInfo.Add("password", settings.Password)
 
 	kube := helm.NewMapping()
-	kube.Add("external_ips", helm.NewList("192.168.77.77"))
+	kube.Add("external_ips", helm.NewList())
 	kube.Add("storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"))
 	kube.Add("registry", registryInfo)
 	kube.Add("organization", settings.Organization)


### PR DESCRIPTION
This exposes the list nature of the external IP to the configuration, so that in setups where multiple IPs are desired (e.g. for a HA-ish setup) that can be used.

The old-style single-IP configuration is still supported