### PR TITLE
helm: Output empty lists

### DIFF
--- a/helm/config.go
+++ b/helm/config.go
@@ -253,6 +253,13 @@ func (list *List) Values() []Node {
 
 func (list List) write(enc *Encoder, prefix string) {
 	emptyLines := enc.useEmptyLines(prefix, list.nodes)
+	if len(list.nodes) == 0 {
+		var leadingSpace = ""
+		if prefix != "" {
+			leadingSpace = " "
+		}
+		fmt.Fprintln(enc, prefix+leadingSpace+"[]")
+	}
 	for _, node := range list.nodes {
 		enc.writeNode(node, &prefix, strings.Repeat(" ", enc.indent-2)+"-", emptyLines)
 	}

--- a/helm/config_test.go
+++ b/helm/config_test.go
@@ -152,6 +152,17 @@ List:
 	values := list.Values()
 	assert.Equal(t, 7, len(values))
 	assert.Equal(t, "3.1415", values[2].String())
+
+	equal(t, NewList(), `---
+[]
+`)
+	equal(t, NewList(NewList()), `---
+- []
+`)
+	equal(t, NewList(NewList(), "1"), `---
+- []
+- "1"
+`)
 }
 
 func TestHelmMapping(t *testing.T) {


### PR DESCRIPTION
The helm chart needs external_ips to be an empty list, so that the helm chart can append to it successfully.

Fixes an issue with #326 