### PR TITLE
run.sh: abort waiting for monit if monit is missing

### DIFF
--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -179,6 +179,9 @@ done
     echo "Ran 'monit stop all'."
 
     while [ $total_services != $(monit summary | grep "^Process" | grep -c "Not monitored") ] ; do
+       if ! pidof monit 2>/dev/null >/dev/null ; then
+           break
+       fi
        sleep 1
     done
 


### PR DESCRIPTION
If monit has already exited, it can't possibly respond to queries about if the processes are still running.  In that case, just stop asking.