### PR TITLE
Extend fissile to generate proper memory requests and limits.

### DIFF
--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -114,7 +114,7 @@ func init() {
 		"mem-limit-factor",
 		"",
 		3,
-		"Slack factor for determing limits from requests",
+		"Slack factor for determining limits from requests",
 	)
 
 	buildHelmCmd.PersistentFlags().StringP(

--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -12,6 +12,7 @@ var (
 	flagBuildHelmOutputDir           string
 	flagBuildHelmDefaultEnvFiles     []string
 	flagBuildHelmUseMemoryLimits     bool
+	flagBuildHelmMemLimitFactor      int
 	flagBuildHelmTagExtra            string
 	flagBuildHelmUseSecretsGenerator bool
 	flagBuildHelmAuthType            string
@@ -27,6 +28,7 @@ var buildHelmCmd = &cobra.Command{
 		flagBuildHelmOutputDir = buildHelmViper.GetString("output-dir")
 		flagBuildHelmDefaultEnvFiles = splitNonEmpty(buildHelmViper.GetString("defaults-file"), ",")
 		flagBuildHelmUseMemoryLimits = buildHelmViper.GetBool("use-memory-limits")
+		flagBuildHelmMemLimitFactor = buildHelmViper.GetInt("mem-limit-factor")
 		flagBuildHelmTagExtra = buildHelmViper.GetString("tag-extra")
 		flagBuildHelmUseSecretsGenerator = buildHelmViper.GetBool("use-secrets-generator")
 		flagBuildOutputGraph = buildViper.GetString("output-graph")
@@ -58,6 +60,7 @@ var buildHelmCmd = &cobra.Command{
 			Organization:        flagDockerOrganization,
 			Repository:          flagRepository,
 			UseMemoryLimits:     flagBuildHelmUseMemoryLimits,
+			MemLimitFactor:      flagBuildHelmMemLimitFactor,
 			FissileVersion:      fissile.Version,
 			Opinions:            opinions,
 			CreateHelmChart:     true,
@@ -105,6 +108,13 @@ func init() {
 		"",
 		true,
 		"Include memory limits when generating helm chart",
+	)
+
+	buildHelmCmd.PersistentFlags().IntP(
+		"mem-limit-factor",
+		"",
+		3,
+		"Slack factor for determing limits from requests",
 	)
 
 	buildHelmCmd.PersistentFlags().StringP(

--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -114,7 +114,7 @@ func init() {
 		"mem-limit-factor",
 		"",
 		3,
-		"Multiplicative factor for determining limits from requests",
+		"Factor for determining limits from requests",
 	)
 
 	buildHelmCmd.PersistentFlags().StringP(

--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -114,7 +114,7 @@ func init() {
 		"mem-limit-factor",
 		"",
 		3,
-		"Slack factor for determining limits from requests",
+		"Multiplicative factor for determining limits from requests",
 	)
 
 	buildHelmCmd.PersistentFlags().StringP(

--- a/cmd/build-kube.go
+++ b/cmd/build-kube.go
@@ -12,6 +12,7 @@ var (
 	flagBuildKubeOutputDir       string
 	flagBuildKubeDefaultEnvFiles []string
 	flagBuildKubeUseMemoryLimits bool
+	flagBuildKubeMemLimitFactor  int
 	flagBuildKubeTagExtra        string
 )
 
@@ -25,6 +26,7 @@ var buildKubeCmd = &cobra.Command{
 		flagBuildKubeOutputDir = buildKubeViper.GetString("output-dir")
 		flagBuildKubeDefaultEnvFiles = splitNonEmpty(buildKubeViper.GetString("defaults-file"), ",")
 		flagBuildKubeUseMemoryLimits = buildKubeViper.GetBool("use-memory-limits")
+		flagBuildKubeMemLimitFactor = buildKubeViper.GetInt("mem-limit-factor")
 		flagBuildKubeTagExtra = buildKubeViper.GetString("tag-extra")
 		flagBuildOutputGraph = buildViper.GetString("output-graph")
 
@@ -54,6 +56,7 @@ var buildKubeCmd = &cobra.Command{
 			Organization:        flagDockerOrganization,
 			Repository:          flagRepository,
 			UseMemoryLimits:     flagBuildKubeUseMemoryLimits,
+			MemLimitFactor:      flagBuildKubeMemLimitFactor,
 			FissileVersion:      fissile.Version,
 			Opinions:            opinions,
 			CreateHelmChart:     false,
@@ -100,6 +103,13 @@ func init() {
 		"",
 		true,
 		"Include memory limits when generating kube configurations",
+	)
+
+	buildKubeCmd.PersistentFlags().IntP(
+		"mem-limit-factor",
+		"",
+		3,
+		"Slack factor for determing limits from requests",
 	)
 
 	buildKubeCmd.PersistentFlags().StringP(

--- a/cmd/build-kube.go
+++ b/cmd/build-kube.go
@@ -109,7 +109,7 @@ func init() {
 		"mem-limit-factor",
 		"",
 		3,
-		"Slack factor for determing limits from requests",
+		"Slack factor for determining limits from requests",
 	)
 
 	buildKubeCmd.PersistentFlags().StringP(

--- a/cmd/build-kube.go
+++ b/cmd/build-kube.go
@@ -109,7 +109,7 @@ func init() {
 		"mem-limit-factor",
 		"",
 		3,
-		"Multiplicative factor for determining limits from requests",
+		"Factor for determining limits from requests",
 	)
 
 	buildKubeCmd.PersistentFlags().StringP(

--- a/cmd/build-kube.go
+++ b/cmd/build-kube.go
@@ -109,7 +109,7 @@ func init() {
 		"mem-limit-factor",
 		"",
 		3,
-		"Slack factor for determining limits from requests",
+		"Multiplicative factor for determining limits from requests",
 	)
 
 	buildKubeCmd.PersistentFlags().StringP(

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -109,9 +109,9 @@ func replicaCheck(role *model.Role, controller *helm.Mapping, service helm.Node,
 		controller.Add("_oddReplicas", fail, helm.Block(block))
 	}
 
-	failSlack := fmt.Sprintf(`{{ fail "memory slack factor must be at least 1" }}`)
-	blockSlack := fmt.Sprintf("if lt (int .Values.sizing.memory.slack) 1")
-	controller.Add("_minSlack", failSlack, helm.Block(blockSlack))
+	failLimitFactor := fmt.Sprintf(`{{ fail "The memory limit factor must be at least 1" }}`)
+	blockLimitFactor := fmt.Sprintf("if lt (int .Values.sizing.memory.limit_factor) 1")
+	controller.Add("_minLimitFactor", failLimitFactor, helm.Block(blockLimitFactor))
 
 	controller.Sort()
 

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -109,6 +109,10 @@ func replicaCheck(role *model.Role, controller *helm.Mapping, service helm.Node,
 		controller.Add("_oddReplicas", fail, helm.Block(block))
 	}
 
+	failSlack := fmt.Sprintf(`{{ fail "memory slack factor must be at least 1" }}`)
+	blockSlack := fmt.Sprintf("if lt (int .Values.sizing.memory.slack) 1")
+	controller.Add("_minSlack", failSlack, helm.Block(blockSlack))
+
 	controller.Sort()
 
 	return nil

--- a/kube/export_settings.go
+++ b/kube/export_settings.go
@@ -14,6 +14,7 @@ type ExportSettings struct {
 	Password            string
 	Organization        string
 	UseMemoryLimits     bool
+	MemLimitFactor      int
 	FissileVersion      string
 	TagExtra            string
 	RoleManifest        *model.RoleManifest

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -38,7 +38,7 @@ func NewPodTemplate(role *model.Role, settings ExportSettings, grapher util.Mode
 	if settings.UseMemoryLimits {
 		if settings.CreateHelmChart {
 			reqMap := helm.NewMapping("memory", fmt.Sprintf("{{ int .Values.sizing.%s.memory }}Mi", roleVarName))
-			limMap := helm.NewMapping("memory", fmt.Sprintf("{{ (mul (int .Values.sizing.memory.slack) (int .Values.sizing.%s.memory)) }}Mi", roleVarName))
+			limMap := helm.NewMapping("memory", fmt.Sprintf("{{ (mul (int .Values.sizing.memory.limit_factor) (int .Values.sizing.%s.memory)) }}Mi", roleVarName))
 
 			reqMap.Set(helm.Block("if .Values.sizing.memory.requests"))
 			limMap.Set(helm.Block("if .Values.sizing.memory.limits"))

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -896,10 +896,61 @@ func TestPodPostFlight(t *testing.T) {
 			containers:
 			-
 				name: post-role
+				resources: ~
 			restartPolicy: OnFailure
 	`, "\t", "    ", -1)
 	if !assert.NoError(yaml.Unmarshal([]byte(expectedYAML), &expected)) {
 		return
 	}
+	testhelpers.IsYAMLSubset(assert, expected, actual)
+}
+
+func TestPodMemory(t *testing.T) {
+	assert := assert.New(t)
+	role := podTestLoadRole(assert, "pre-role")
+	if role == nil {
+		return
+	}
+	pod, err := NewPod(role, ExportSettings{
+		Opinions:        model.NewEmptyOpinions(),
+		UseMemoryLimits: true,
+		MemLimitFactor:  3,
+	}, nil)
+	if !assert.NoError(err, "Failed to create pod from role pre-role") {
+		return
+	}
+	assert.NotNil(pod)
+
+	yamlConfig := &bytes.Buffer{}
+	if err := helm.NewEncoder(yamlConfig).Encode(pod); !assert.NoError(err) {
+		return
+	}
+
+	var expected, actual interface{}
+	if !assert.NoError(yaml.Unmarshal(yamlConfig.Bytes(), &actual)) {
+		return
+	}
+
+	expectedYAML := strings.Replace(`---
+		apiVersion: v1
+		kind: Pod
+		metadata:
+			name: pre-role
+		spec:
+			containers:
+			-
+				name: pre-role
+				resources:
+					requests:
+						memory: 128Mi
+					limits:
+						memory: 384Mi
+			restartPolicy: OnFailure
+			terminationGracePeriodSeconds: 600
+	`, "\t", "    ", -1)
+	if !assert.NoError(yaml.Unmarshal([]byte(expectedYAML), &expected)) {
+		return
+	}
+
 	testhelpers.IsYAMLSubset(assert, expected, actual)
 }

--- a/kube/values.go
+++ b/kube/values.go
@@ -38,11 +38,14 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	}
 	env.Sort()
 
-	sizing := helm.NewMapping(
-		"HA", false,
-		"memory", helm.NewMapping("slack", settings.MemLimitFactor,
-			"requests", false,
-			"limits", false))
+	memSizing := helm.NewMapping()
+	memSizing.Add("limit_factor", settings.MemLimitFactor, helm.Comment("Factor to calculate the limits from the requests\nMust be 1 or larger."))
+	memSizing.Add("requests", false, helm.Comment("Flag to activate memory requests"))
+	memSizing.Add("limits", false, helm.Comment("Flag to activate memory limits"))
+
+	sizing := helm.NewMapping()
+	sizing.Add("HA", false, helm.Comment("Flag to activate high-availability mode"))
+	sizing.Add("memory", memSizing, helm.Comment("Global memory configuration"))
 
 	for _, role := range settings.RoleManifest.Roles {
 		if role.IsDevRole() || role.Run.FlightStage == model.FlightStageManual {

--- a/kube/values.go
+++ b/kube/values.go
@@ -38,7 +38,12 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	}
 	env.Sort()
 
-	sizing := helm.NewMapping("HA", false, "memory_slack", settings.MemLimitFactor)
+	sizing := helm.NewMapping(
+		"HA", false,
+		"memory", helm.NewMapping("slack", settings.MemLimitFactor,
+			"requests", false,
+			"limits", false))
+
 	for _, role := range settings.RoleManifest.Roles {
 		if role.IsDevRole() || role.Run.FlightStage == model.FlightStageManual {
 			continue

--- a/kube/values.go
+++ b/kube/values.go
@@ -38,7 +38,7 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	}
 	env.Sort()
 
-	sizing := helm.NewMapping("HA", false)
+	sizing := helm.NewMapping("HA", false, "memory_slack", settings.MemLimitFactor)
 	for _, role := range settings.RoleManifest.Roles {
 		if role.IsDevRole() || role.Run.FlightStage == model.FlightStageManual {
 			continue


### PR DESCRIPTION
Ref: https://trello.com/c/UEvqSutH/576-sane-memory-limits-for-all-pods

See also SCF branch https://github.com/SUSE/scf/tree/aku/UEvqSutH-mem-limits
where the role-manifest is modified based on memory measurements for the SCF roles.

