### PR TITLE
Implement CPU limits in fissile. Analogous to memory limits.

### DIFF
--- a/cmd/build-helm.go
+++ b/cmd/build-helm.go
@@ -12,7 +12,7 @@ var (
 	flagBuildHelmOutputDir           string
 	flagBuildHelmDefaultEnvFiles     []string
 	flagBuildHelmUseMemoryLimits     bool
-	flagBuildHelmMemLimitFactor      int
+	flagBuildHelmUseCPULimits        bool
 	flagBuildHelmTagExtra            string
 	flagBuildHelmUseSecretsGenerator bool
 	flagBuildHelmAuthType            string
@@ -28,7 +28,7 @@ var buildHelmCmd = &cobra.Command{
 		flagBuildHelmOutputDir = buildHelmViper.GetString("output-dir")
 		flagBuildHelmDefaultEnvFiles = splitNonEmpty(buildHelmViper.GetString("defaults-file"), ",")
 		flagBuildHelmUseMemoryLimits = buildHelmViper.GetBool("use-memory-limits")
-		flagBuildHelmMemLimitFactor = buildHelmViper.GetInt("mem-limit-factor")
+		flagBuildHelmUseCPULimits = buildHelmViper.GetBool("use-cpu-limits")
 		flagBuildHelmTagExtra = buildHelmViper.GetString("tag-extra")
 		flagBuildHelmUseSecretsGenerator = buildHelmViper.GetBool("use-secrets-generator")
 		flagBuildOutputGraph = buildViper.GetString("output-graph")
@@ -60,7 +60,7 @@ var buildHelmCmd = &cobra.Command{
 			Organization:        flagDockerOrganization,
 			Repository:          flagRepository,
 			UseMemoryLimits:     flagBuildHelmUseMemoryLimits,
-			MemLimitFactor:      flagBuildHelmMemLimitFactor,
+			UseCPULimits:        flagBuildHelmUseCPULimits,
 			FissileVersion:      fissile.Version,
 			Opinions:            opinions,
 			CreateHelmChart:     true,
@@ -110,11 +110,11 @@ func init() {
 		"Include memory limits when generating helm chart",
 	)
 
-	buildHelmCmd.PersistentFlags().IntP(
-		"mem-limit-factor",
+	buildHelmCmd.PersistentFlags().BoolP(
+		"use-cpu-limits",
 		"",
-		3,
-		"Factor for determining limits from requests",
+		true,
+		"Include cpu limits when generating helm chart",
 	)
 
 	buildHelmCmd.PersistentFlags().StringP(

--- a/cmd/build-kube.go
+++ b/cmd/build-kube.go
@@ -12,7 +12,7 @@ var (
 	flagBuildKubeOutputDir       string
 	flagBuildKubeDefaultEnvFiles []string
 	flagBuildKubeUseMemoryLimits bool
-	flagBuildKubeMemLimitFactor  int
+	flagBuildKubeUseCPULimits    bool
 	flagBuildKubeTagExtra        string
 )
 
@@ -26,7 +26,7 @@ var buildKubeCmd = &cobra.Command{
 		flagBuildKubeOutputDir = buildKubeViper.GetString("output-dir")
 		flagBuildKubeDefaultEnvFiles = splitNonEmpty(buildKubeViper.GetString("defaults-file"), ",")
 		flagBuildKubeUseMemoryLimits = buildKubeViper.GetBool("use-memory-limits")
-		flagBuildKubeMemLimitFactor = buildKubeViper.GetInt("mem-limit-factor")
+		flagBuildKubeUseCPULimits = buildKubeViper.GetBool("use-cpu-limits")
 		flagBuildKubeTagExtra = buildKubeViper.GetString("tag-extra")
 		flagBuildOutputGraph = buildViper.GetString("output-graph")
 
@@ -56,7 +56,7 @@ var buildKubeCmd = &cobra.Command{
 			Organization:        flagDockerOrganization,
 			Repository:          flagRepository,
 			UseMemoryLimits:     flagBuildKubeUseMemoryLimits,
-			MemLimitFactor:      flagBuildKubeMemLimitFactor,
+			UseCPULimits:        flagBuildKubeUseCPULimits,
 			FissileVersion:      fissile.Version,
 			Opinions:            opinions,
 			CreateHelmChart:     false,
@@ -105,11 +105,11 @@ func init() {
 		"Include memory limits when generating kube configurations",
 	)
 
-	buildKubeCmd.PersistentFlags().IntP(
-		"mem-limit-factor",
+	buildKubeCmd.PersistentFlags().BoolP(
+		"use-cpu-limits",
 		"",
-		3,
-		"Factor for determining limits from requests",
+		true,
+		"Include cpu limits when generating helm chart",
 	)
 
 	buildKubeCmd.PersistentFlags().StringP(

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -109,10 +109,6 @@ func replicaCheck(role *model.Role, controller *helm.Mapping, service helm.Node,
 		controller.Add("_oddReplicas", fail, helm.Block(block))
 	}
 
-	failLimitFactor := fmt.Sprintf(`{{ fail "The memory limit factor must be at least 1" }}`)
-	blockLimitFactor := fmt.Sprintf("if lt (int .Values.sizing.memory.limit_factor) 1")
-	controller.Add("_minLimitFactor", failLimitFactor, helm.Block(blockLimitFactor))
-
 	controller.Sort()
 
 	return nil

--- a/kube/export_settings.go
+++ b/kube/export_settings.go
@@ -14,7 +14,7 @@ type ExportSettings struct {
 	Password            string
 	Organization        string
 	UseMemoryLimits     bool
-	MemLimitFactor      int
+	UseCPULimits        bool
 	FissileVersion      string
 	TagExtra            string
 	RoleManifest        *model.RoleManifest

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -81,12 +81,12 @@ func NewPodTemplate(role *model.Role, settings ExportSettings, grapher util.Mode
 		} else {
 			if role.Run.CPU != nil {
 				if role.Run.CPU.Request != nil {
-					requests.Add("cpu", fmt.Sprintf("%dm", int(0.5+1000**role.Run.CPU.Request)))
+					requests.Add("cpu", fmt.Sprintf("%dm", int(*role.Run.CPU.Request*1000+0.5)))
 				} else {
 					requests.Add("cpu", nil)
 				}
 				if role.Run.CPU.Limit != nil {
-					limits.Add("cpu", fmt.Sprintf("%dm", int(0.5+1000**role.Run.CPU.Limit)))
+					limits.Add("cpu", fmt.Sprintf("%dm", int(*role.Run.CPU.Limit*1000+0.5)))
 				} else {
 					limits.Add("cpu", nil)
 				}

--- a/model/roles.go
+++ b/model/roles.go
@@ -80,9 +80,9 @@ type RoleRun struct {
 	Capabilities      []string              `yaml:"capabilities"`
 	PersistentVolumes []*RoleRunVolume      `yaml:"persistent-volumes"`
 	SharedVolumes     []*RoleRunVolume      `yaml:"shared-volumes"`
-	MemRequest        int                   `yaml:"memory"`
+	MemRequest        *int64                `yaml:"memory"`
 	Memory            *RoleRunMemory        `yaml:"mem"`
-	VirtualCPUs       float64               `yaml:"virtual-cpus"`
+	VirtualCPUs       *float64              `yaml:"virtual-cpus"`
 	CPU               *RoleRunCPU           `yaml:"cpu"`
 	ExposedPorts      []*RoleRunExposedPort `yaml:"exposed-ports"`
 	FlightStage       FlightStage           `yaml:"flight-stage"`
@@ -1269,20 +1269,22 @@ func validateRoleMemory(role *Role) validation.ErrorList {
 	allErrs := validation.ErrorList{}
 
 	if role.Run.Memory == nil {
-		allErrs = append(allErrs, validation.ValidateNonnegativeField(int64(role.Run.MemRequest),
-			fmt.Sprintf("roles[%s].run.memory", role.Name))...)
-		mreq := int64(role.Run.MemRequest)
-		role.Run.Memory = &RoleRunMemory{Request: &mreq}
+		if role.Run.MemRequest != nil {
+			allErrs = append(allErrs, validation.ValidateNonnegativeField(*role.Run.MemRequest,
+				fmt.Sprintf("roles[%s].run.memory", role.Name))...)
+		}
+		role.Run.Memory = &RoleRunMemory{Request: role.Run.MemRequest}
 		return allErrs
 	}
 
 	// assert: role.Run.Memory != nil
 
 	if role.Run.Memory.Request == nil {
-		allErrs = append(allErrs, validation.ValidateNonnegativeField(int64(role.Run.MemRequest),
-			fmt.Sprintf("roles[%s].run.memory", role.Name))...)
-		mreq := int64(role.Run.MemRequest)
-		role.Run.Memory.Request = &mreq
+		if role.Run.MemRequest != nil {
+			allErrs = append(allErrs, validation.ValidateNonnegativeField(*role.Run.MemRequest,
+				fmt.Sprintf("roles[%s].run.memory", role.Name))...)
+		}
+		role.Run.Memory.Request = role.Run.MemRequest
 	} else {
 		allErrs = append(allErrs, validation.ValidateNonnegativeField(*role.Run.Memory.Request,
 			fmt.Sprintf("roles[%s].run.mem.request", role.Name))...)
@@ -1303,18 +1305,22 @@ func validateRoleCPU(role *Role) validation.ErrorList {
 	allErrs := validation.ErrorList{}
 
 	if role.Run.CPU == nil {
-		allErrs = append(allErrs, validation.ValidateNonnegativeFieldFloat(role.Run.VirtualCPUs,
-			fmt.Sprintf("roles[%s].run.virtual-cpus", role.Name))...)
-		role.Run.CPU = &RoleRunCPU{Request: &role.Run.VirtualCPUs}
+		if role.Run.VirtualCPUs != nil {
+			allErrs = append(allErrs, validation.ValidateNonnegativeFieldFloat(*role.Run.VirtualCPUs,
+				fmt.Sprintf("roles[%s].run.virtual-cpus", role.Name))...)
+		}
+		role.Run.CPU = &RoleRunCPU{Request: role.Run.VirtualCPUs}
 		return allErrs
 	}
 
 	// assert: role.Run.CPU != nil
 
 	if role.Run.CPU.Request == nil {
-		allErrs = append(allErrs, validation.ValidateNonnegativeFieldFloat(role.Run.VirtualCPUs,
-			fmt.Sprintf("roles[%s].run.virtual-cpus", role.Name))...)
-		role.Run.CPU.Request = &role.Run.VirtualCPUs
+		if role.Run.VirtualCPUs != nil {
+			allErrs = append(allErrs, validation.ValidateNonnegativeFieldFloat(*role.Run.VirtualCPUs,
+				fmt.Sprintf("roles[%s].run.virtual-cpus", role.Name))...)
+		}
+		role.Run.CPU.Request = role.Run.VirtualCPUs
 	} else {
 		allErrs = append(allErrs, validation.ValidateNonnegativeFieldFloat(*role.Run.CPU.Request,
 			fmt.Sprintf("roles[%s].run.cpu.request", role.Name))...)

--- a/test-assets/role-manifests/bad-cv-type-internal.yml
+++ b/test-assets/role-manifests/bad-cv-type-internal.yml
@@ -19,6 +19,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/bad-cv-type.yml
+++ b/test-assets/role-manifests/bad-cv-type.yml
@@ -19,6 +19,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/bosh-run-bad-memory.yml
+++ b/test-assets/role-manifests/bosh-run-bad-memory.yml
@@ -4,4 +4,4 @@ roles:
   jobs: []
   run:
     memory: -10
-    cpu: -2
+    virtual-cpus: 2

--- a/test-assets/role-manifests/bosh-run-missing.yml
+++ b/test-assets/role-manifests/bosh-run-missing.yml
@@ -8,6 +8,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/docker-run-env.yml
+++ b/test-assets/role-manifests/docker-run-env.yml
@@ -11,6 +11,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/multiple-good.yml
+++ b/test-assets/role-manifests/multiple-good.yml
@@ -13,6 +13,8 @@ roles:
     release_name: ntp
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/non-bosh-roles.yml
+++ b/test-assets/role-manifests/non-bosh-roles.yml
@@ -11,6 +11,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/pods.yml
+++ b/test-assets/role-manifests/pods.yml
@@ -9,6 +9,11 @@ roles:
   run:
     flight-stage: pre-flight
     memory: 128
+    mem:
+      limit: 384
+    virtual-cpus: 2
+    cpu:
+      limit: 4
 - name: post-role
   type: bosh-task
   tags: [stop-on-failure]

--- a/test-assets/role-manifests/templates-non.yml
+++ b/test-assets/role-manifests/templates-non.yml
@@ -19,6 +19,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/tor-good.yml
+++ b/test-assets/role-manifests/tor-good.yml
@@ -19,6 +19,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+     foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/tor-validation-issues.yml
+++ b/test-assets/role-manifests/tor-validation-issues.yml
@@ -22,6 +22,8 @@ roles:
       properties.tor.bogus: BOGUS
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/tor-validation-ok.yml
+++ b/test-assets/role-manifests/tor-validation-ok.yml
@@ -19,6 +19,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/variables-badly-sorted.yml
+++ b/test-assets/role-manifests/variables-badly-sorted.yml
@@ -19,6 +19,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/test-assets/role-manifests/variables-without-decl.yml
+++ b/test-assets/role-manifests/variables-without-decl.yml
@@ -19,6 +19,8 @@ roles:
     release_name: tor
 - name: foorole
   type: bosh-task
+  run:
+    foo: x
   jobs:
   - name: tor
     release_name: tor

--- a/validation/validation.go
+++ b/validation/validation.go
@@ -14,6 +14,15 @@ func ValidateNonnegativeField(value int64, field string) ErrorList {
 	return allErrs
 }
 
+// ValidateNonnegativeFieldFloat validates that given value is not negative.
+func ValidateNonnegativeFieldFloat(value float64, field string) ErrorList {
+	allErrs := ErrorList{}
+	if value < 0 {
+		allErrs = append(allErrs, Invalid(field, value, `must be greater than or equal to 0`))
+	}
+	return allErrs
+}
+
 // ValidatePort validates that given value is valid and in range 0 - 65535.
 func ValidatePort(port string, field string) ErrorList {
 	allErrs := ErrorList{}


### PR DESCRIPTION
Ref: https://trello.com/c/6925zx7v/584-2-cpu-being-able-to-enable-cpu-limits-whilst-leaving-them-off-by-default

Both cpu and memory request and limits got redone.
For the spec worked from see the ref above, top comments from Mar 9.

* The limit-factors are gone. Role manifest specifies both requests and limits, no implicit coupling.
* By default all requests and limits are globally off in the `values.yaml`.
* The inactive defaults are inherited from the manifest.
* It is possible to set a request or limit for a specific role to `~` , i.e. null and the role will disable this when starting the role. The template checks both global flag and per-role information before activating a request or limit (`if and ...`).

Currently tested against SCF, with the memory limits.
Inactive, globally active, and globally active with mysql request disabled.


