### PR TITLE
Don't allow empty lists

### DIFF
--- a/helm/config.go
+++ b/helm/config.go
@@ -253,13 +253,6 @@ func (list *List) Values() []Node {
 
 func (list List) write(enc *Encoder, prefix string) {
 	emptyLines := enc.useEmptyLines(prefix, list.nodes)
-	if len(list.nodes) == 0 {
-		var leadingSpace = ""
-		if prefix != "" {
-			leadingSpace = " "
-		}
-		fmt.Fprintln(enc, prefix+leadingSpace+"[]")
-	}
 	for _, node := range list.nodes {
 		enc.writeNode(node, &prefix, strings.Repeat(" ", enc.indent-2)+"-", emptyLines)
 	}

--- a/helm/config_test.go
+++ b/helm/config_test.go
@@ -152,17 +152,6 @@ List:
 	values := list.Values()
 	assert.Equal(t, 7, len(values))
 	assert.Equal(t, "3.1415", values[2].String())
-
-	equal(t, NewList(), `---
-[]
-`)
-	equal(t, NewList(NewList()), `---
-- []
-`)
-	equal(t, NewList(NewList(), "1"), `---
-- []
-- "1"
-`)
 }
 
 func TestHelmMapping(t *testing.T) {

--- a/kube/service.go
+++ b/kube/service.go
@@ -110,9 +110,7 @@ func NewClusterIPService(role *model.Role, headless bool, public bool, settings 
 			// use .kube.external_ip instead (as the single address)
 			externalIP = strings.Replace(`{{
 				default
-					( append .Values.kube.external_ips
-						( .Values.kube.external_ip )
-					)
+					( list .Values.kube.external_ip )
 					.Values.kube.external_ips
 				| toJson
 			}}`, "\n", " ", -1)


### PR DESCRIPTION
This causes unnecessary upgrade failures (due to new, empty, volume lists).  See bsc#1084412