### PR TITLE
Remove LICENSE Check for a final release

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -731,10 +731,6 @@ func isFinalReleasePath(releasePath string) (bool, error) {
 		return false, err
 	}
 
-	if err := util.ValidatePath(filepath.Join(releasePath, "LICENSE"), false, "release 'LICENSE' file"); err != nil {
-		return false, err
-	}
-
 	return true, nil
 }
 


### PR DESCRIPTION
Hi,

`LICENSE` is not required for loading a final release, so remove it from final release check. Thanks!