### PR TITLE
Return the release type Dev or Final in fissile show release

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -66,7 +66,7 @@ func (f *Fissile) ListPackages(verbose bool) error {
 			releasePath = color.WhiteString(" (%s)", release.Path)
 		}
 
-		f.UI.Println(color.GreenString("Dev release %s (%s)%s", color.YellowString(release.Name), color.MagentaString(release.Version), releasePath))
+		f.UI.Println(color.GreenString("%s release %s (%s)%s", release.ReleaseType(), color.YellowString(release.Name), color.MagentaString(release.Version), releasePath))
 
 		for _, pkg := range release.Packages {
 			var isCached string
@@ -104,7 +104,7 @@ func (f *Fissile) ListJobs(verbose bool) error {
 			releasePath = color.WhiteString(" (%s)", release.Path)
 		}
 
-		f.UI.Println(color.GreenString("Dev release %s (%s)%s", color.YellowString(release.Name), color.MagentaString(release.Version), releasePath))
+		f.UI.Println(color.GreenString("%s release %s (%s)%s", release.ReleaseType(), color.YellowString(release.Name), color.MagentaString(release.Version), releasePath))
 
 		for _, job := range release.Jobs {
 			var isCached string
@@ -209,8 +209,8 @@ func (f *Fissile) SerializeJobs() (map[string]interface{}, error) {
 func (f *Fissile) listPropertiesForHuman() {
 	// Human readable output.
 	for _, release := range f.releases {
-		f.UI.Println(color.GreenString("Dev release %s (%s)",
-			color.YellowString(release.Name), color.MagentaString(release.Version)))
+		f.UI.Println(color.GreenString("%s release %s (%s)",
+			release.ReleaseType(), color.YellowString(release.Name), color.MagentaString(release.Version)))
 
 		for _, job := range release.Jobs {
 			f.UI.Printf("%s (%s): %s\n", color.YellowString(job.Name),

--- a/model/release.go
+++ b/model/release.go
@@ -230,6 +230,15 @@ func (r *Release) manifestFilePath() string {
 	return filepath.Join(r.getDevReleaseManifestsDir(), r.getDevReleaseManifestFilename())
 }
 
+// ReleaseType returns a string identifying the type of the release: Dev or Final.
+func (r *Release) ReleaseType() string {
+	if r.FinalRelease {
+		return "Final"
+	}
+
+	return "Dev"
+}
+
 // Marshal implements the util.Marshaler interface
 func (r *Release) Marshal() (interface{}, error) {
 	jobFingerprints := make([]string, 0, len(r.Jobs))


### PR DESCRIPTION
We have a mix of development and final releases in our builds. It would help to quickly see which ones were originally final releases where we supplied the tarball and which ones were compiled from scratch for the build.

I added a function to return the release type, which is either `Dev` or `Final`.

The UI print functions were modified to call the release type
function to print it in the `fissile show release` output, e.g.
```
Final release nginx (1.12.2+dev.1)
nginx (e7dc968f9daf5b31ff4ad6edf048306f45a70bbb):
There are 1 jobs present.

Final release nginx (1.12.2+dev.1)
nginx (d6ddf5c4782669341b260a27c53208d32a17b3a5)
There are 1 packages present.
```

What do you think about this idea? Thanks in advance for your feedback.