### PR TITLE
Support hostpath volumes

### DIFF
--- a/kube/pod.go
+++ b/kube/pod.go
@@ -242,7 +242,11 @@ func getContainerPorts(role *model.Role, settings ExportSettings) (helm.Node, er
 func getVolumeMounts(role *model.Role) helm.Node {
 	var mounts []helm.Node
 	for _, volume := range role.Run.Volumes {
-		mounts = append(mounts, helm.NewMapping("mountPath", volume.Path, "name", volume.Tag, "readOnly", false))
+		mount := helm.NewMapping("mountPath", volume.Path, "name", volume.Tag, "readOnly", false)
+		if volume.Type == model.VolumeTypeHost {
+			mount.Set(helm.Block("if .Values.kube.hostpath_available"))
+		}
+		mounts = append(mounts, mount)
 	}
 	if len(mounts) == 0 {
 		return nil

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -273,7 +273,9 @@ func getNonClaimVolumes(role *model.Role) helm.Node {
 		switch volume.Type {
 		case model.VolumeTypeHost:
 			hostPathInfo := helm.NewMapping("path", volume.Path, "type", "Directory")
-			mounts = append(mounts, helm.NewMapping("name", volume.Tag, "hostPath", hostPathInfo))
+			volumeEntry := helm.NewMapping("name", volume.Tag, "hostPath", hostPathInfo)
+			volumeEntry.Set(helm.Block("if .Values.kube.hostpath_available"))
+			mounts = append(mounts, volumeEntry)
 		}
 	}
 	if len(mounts) == 0 {

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -240,10 +240,7 @@ func getContainerPorts(role *model.Role, settings ExportSettings) (helm.Node, er
 // getVolumeMounts gets the list of volume mounts for a role
 func getVolumeMounts(role *model.Role) helm.Node {
 	var mounts []helm.Node
-	for _, volume := range role.Run.PersistentVolumes {
-		mounts = append(mounts, helm.NewMapping("mountPath", volume.Path, "name", volume.Tag, "readOnly", false))
-	}
-	for _, volume := range role.Run.SharedVolumes {
+	for _, volume := range role.Run.Volumes {
 		mounts = append(mounts, helm.NewMapping("mountPath", volume.Path, "name", volume.Tag, "readOnly", false))
 	}
 	if len(mounts) == 0 {

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -100,15 +100,25 @@ func TestPodGetVolumes(t *testing.T) {
 		return
 	}
 
-	claims := getAllVolumeClaims(role, false)
+	claims := getVolumeClaims(role, false)
 	assert.Len(claims, 2, "expected two claims")
+
+	var persistentVolume, sharedVolume *model.RoleRunVolume
+	for _, volume := range role.Run.Volumes {
+		switch volume.Type {
+		case model.VolumeTypePersistent:
+			persistentVolume = volume
+		case model.VolumeTypeShared:
+			sharedVolume = volume
+		}
+	}
 
 	var persistentClaim, sharedClaim helm.Node
 	for _, claim := range claims {
 		switch claim.Get("metadata", "name").String() {
-		case role.Run.PersistentVolumes[0].Tag:
+		case string(persistentVolume.Tag):
 			persistentClaim = claim
-		case role.Run.SharedVolumes[0].Tag:
+		case string(sharedVolume.Tag):
 			sharedClaim = claim
 		default:
 			assert.Fail("Got unexpected claim", "%s", claim)

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -170,15 +170,17 @@ func TestPodGetVolumeMounts(t *testing.T) {
 	}
 
 	volumeMounts := getVolumeMounts(role).Values()
-	assert.Len(volumeMounts, 2)
+	assert.Len(volumeMounts, 3)
 
-	var persistentMount, sharedMount helm.Node
+	var persistentMount, sharedMount, hostMount helm.Node
 	for _, mount := range volumeMounts {
 		switch mount.Get("name").String() {
 		case "persistent-volume":
 			persistentMount = mount
 		case "shared-volume":
 			sharedMount = mount
+		case "host-volume":
+			hostMount = mount
 		default:
 			assert.Fail("Got unexpected volume mount", "%+v", mount)
 		}
@@ -187,6 +189,8 @@ func TestPodGetVolumeMounts(t *testing.T) {
 	assert.Equal("false", persistentMount.Get("readOnly").String())
 	assert.Equal("/mnt/shared", sharedMount.Get("mountPath").String())
 	assert.Equal("false", sharedMount.Get("readOnly").String())
+	assert.Equal("/sys/fs/cgroup", hostMount.Get("mountPath").String())
+	assert.Equal("false", hostMount.Get("readOnly").String())
 }
 
 func TestPodGetEnvVars(t *testing.T) {

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -53,6 +53,7 @@ func podTemplateTestLoadRole(assert *assert.Assertions) *model.Role {
 type Sample struct {
 	desc     string
 	input    interface{}
+	helm     map[string]interface{}
 	expected string
 	err      string
 }

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -217,11 +217,20 @@ func TestStatefulSetVolumes(t *testing.T) {
 						name: myrole
 						volumeMounts:
 						-
+							name: host-volume
+							mountPath: /sys/fs/cgroup
+						-
 							name: persistent-volume
 							mountPath: /mnt/persistent
 						-
 							name: shared-volume
 							mountPath: /mnt/shared
+					volumes:
+					-
+						name: host-volume
+						hostPath:
+							path: /sys/fs/cgroup
+							type: Directory
 			volumeClaimTemplates:
 				-
 					metadata:

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -1,7 +1,6 @@
 package kube
 
 import (
-	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -83,14 +82,13 @@ func TestStatefulSetPorts(t *testing.T) {
 
 	items = append(items, statefulset)
 	objects := helm.NewMapping("items", helm.NewNode(items))
-	yamlConfig := &bytes.Buffer{}
-	if err := helm.NewEncoder(yamlConfig).Encode(objects); !assert.NoError(err) {
+
+	actual, err := testhelpers.RoundtripNode(objects, nil)
+	if !assert.NoError(err) {
 		return
 	}
-	var expected, actual interface{}
-	if !assert.NoError(yaml.Unmarshal(yamlConfig.Bytes(), &actual)) {
-		return
-	}
+
+	var expected interface{}
 
 	expectedYAML := strings.Replace(`---
 		items:
@@ -189,16 +187,11 @@ func TestStatefulSetVolumes(t *testing.T) {
 		return
 	}
 
-	yamlConfig := &bytes.Buffer{}
-	err = helm.NewEncoder(yamlConfig).Encode(statefulset)
+	actual, err := testhelpers.RoundtripNode(statefulset, nil)
 	if !assert.NoError(err) {
 		return
 	}
-
-	var expected, actual interface{}
-	if !assert.NoError(yaml.Unmarshal(yamlConfig.Bytes(), &actual)) {
-		return
-	}
+	var expected interface{}
 
 	expectedYAML := strings.Replace(`---
 		metadata:

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -250,4 +250,18 @@ func TestStatefulSetVolumes(t *testing.T) {
 		return
 	}
 	testhelpers.IsYAMLSubset(assert, expected, actual)
+
+	// Check that not having hostpath disables the hostpath volume
+	overrides := map[string]interface{}{
+		"Values.kube.hostpath_available": false,
+	}
+	actual, err = testhelpers.RoundtripNode(statefulset, overrides)
+	if !assert.NoError(err) {
+		return
+	}
+	volumes := actual
+	for _, k := range []string{"spec", "template", "spec", "volumes"} {
+		volumes = volumes.(map[interface{}]interface{})[k]
+	}
+	assert.Empty(volumes, "Hostpath volumes should not be available")
 }

--- a/kube/values.go
+++ b/kube/values.go
@@ -132,11 +132,11 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 		}
 
 		diskSizes := helm.NewMapping()
-		for _, volume := range role.Run.PersistentVolumes {
-			diskSizes.Add(makeVarName(volume.Tag), volume.Size)
-		}
-		for _, volume := range role.Run.SharedVolumes {
-			diskSizes.Add(makeVarName(volume.Tag), volume.Size)
+		for _, volume := range role.Run.Volumes {
+			switch volume.Type {
+			case model.VolumeTypePersistent, model.VolumeTypeShared:
+				diskSizes.Add(makeVarName(volume.Tag), volume.Size)
+			}
 		}
 		if len(diskSizes.Names()) > 0 {
 			entry.Add("disk_sizes", diskSizes.Sort())

--- a/kube/values.go
+++ b/kube/values.go
@@ -180,6 +180,7 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	kube.Add("external_ips", helm.NewList())
 	kube.Add("secrets_generation_counter", 1, helm.Comment("Increment this counter to rotate all generated secrets"))
 	kube.Add("storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"))
+	kube.Add("hostpath_available", true, helm.Comment("Whether HostPath volume mounts are available"))
 	kube.Add("registry", registryInfo)
 	kube.Add("organization", settings.Organization)
 

--- a/test-assets/role-manifests/volumes.yml
+++ b/test-assets/role-manifests/volumes.yml
@@ -16,6 +16,10 @@ roles:
     - path: /mnt/shared
       tag: shared-volume
       size: 40 # cakes
+    volumes:
+    - path: /sys/fs/cgroup
+      type: host
+      tag: host-volume
 configuration:
   templates:
     fox: ((SOME_VAR))

--- a/testhelpers/helm_helper.go
+++ b/testhelpers/helm_helper.go
@@ -1,0 +1,81 @@
+package testhelpers
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/SUSE/fissile/helm"
+
+	"gopkg.in/yaml.v2"
+)
+
+// RenderNode renders a helm node given the configuration.
+// The configuration may be nil, or map[string]interface{}
+// If it is nil, default values are used.
+// Otherwise, if the keys contains dots, they are interpreted as the paths
+// to the elements to override.  If they do not contain dots, the map itself
+// is considered the override.
+func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
+	actualConfig := map[string]interface{}{
+		"Values": map[string]interface{}{
+			"kube": map[string]interface{}{
+				"hostpath_available": true,
+			},
+		},
+	}
+	if overrides, ok := config.(map[string]interface{}); ok {
+		for k, v := range overrides {
+			actualConfig = mergeMap(actualConfig, v, strings.Split(k, ".")...)
+		}
+	} else if config != nil {
+		return nil, fmt.Errorf("Invalid config %+v", config)
+	}
+
+	var helmConfig, yamlConfig bytes.Buffer
+
+	if err := helm.NewEncoder(&helmConfig).Encode(node); err != nil {
+		return nil, err
+	}
+	tmpl, err := template.New("").Parse(string(helmConfig.Bytes()))
+	if err != nil {
+		return nil, err
+	}
+	if err = tmpl.Execute(&yamlConfig, actualConfig); err != nil {
+		return nil, err
+	}
+	return yamlConfig.Bytes(), nil
+}
+
+// RoundtripNode serializes and then unserializes a helm node.  The config
+// override is identical to RenderNode().
+func RoundtripNode(node helm.Node, config interface{}) (interface{}, error) {
+	actualBytes, err := RenderNode(node, config)
+	if err != nil {
+		return nil, err
+	}
+
+	var actual interface{}
+	if err := yaml.Unmarshal(actualBytes, &actual); err != nil {
+		return nil, err
+	}
+	return actual, nil
+}
+
+// mergeMap returns the input map, but with an override applied.  An override
+// is a key path and a value to replace with.
+func mergeMap(obj map[string]interface{}, value interface{}, key ...string) map[string]interface{} {
+	if len(key) < 1 {
+		panic("No keys")
+	}
+	if len(key) == 1 {
+		obj[key[0]] = value
+		return obj
+	}
+	if _, ok := obj[key[0]]; !ok {
+		obj[key[0]] = make(map[string]interface{})
+	}
+	obj[key[0]] = mergeMap(obj[key[0]].(map[string]interface{}), value, key[1:]...)
+	return obj
+}

--- a/testhelpers/serialization_helper.go
+++ b/testhelpers/serialization_helper.go
@@ -2,15 +2,25 @@ package testhelpers
 
 import (
 	"fmt"
+	"os"
 	"reflect"
 	"strings"
 
 	"github.com/stretchr/testify/assert"
+	yaml "gopkg.in/yaml.v2"
 )
 
 // IsYAMLSubset asserts that all items in the expected properties are in the actual properties
 func IsYAMLSubset(assert *assert.Assertions, expected, actual interface{}) bool {
-	return isYAMLSubsetInner(assert, expected, actual, nil)
+	result := isYAMLSubsetInner(assert, expected, actual, nil)
+	if !result {
+		buf, err := yaml.Marshal(actual)
+		if assert.NoError(err) {
+			_, err := os.Stderr.Write(buf)
+			assert.NoError(err)
+		}
+	}
+	return result
 }
 
 func isYAMLSubsetInner(assert *assert.Assertions, expected, actual interface{}, prefix []string) bool {


### PR DESCRIPTION
This adds support for hostpath volumes, for SUSE/scf#1345 to mount the external `/sys/fs/cgroup` in `diego-cell`.  It also accepts (but does not implement) emptyDir volumes, sort of on the way to #340 (if we decide to implement this way, rather than `empty-dir: true` as suggested).

This is more for discussion than merging; for one thing, I'm not sure hostpath would always be available.