### PR TITLE
diff: better formatting for hashes

### DIFF
--- a/app/fissile_test.go
+++ b/app/fissile_test.go
@@ -505,14 +505,14 @@ func TestDevDiffConfigurations(t *testing.T) {
 		sort.Strings(hashDiffs.AddedKeys)
 		assert.Equal("acceptance_tests.include_route_services", hashDiffs.AddedKeys[0])
 		assert.Equal("app_ssh.oauth_client_id", hashDiffs.AddedKeys[1])
-		assert.Equal("cf.acceptance-tests.acceptance_tests.include_route_services", hashDiffs.AddedKeys[2])
-		assert.Equal("cf.cloud_controller_ng.app_ssh.oauth_client_id", hashDiffs.AddedKeys[3])
+		assert.Equal("cf:acceptance-tests:acceptance_tests.include_route_services", hashDiffs.AddedKeys[2])
+		assert.Equal("cf:cloud_controller_ng:app_ssh.oauth_client_id", hashDiffs.AddedKeys[3])
 	}
 	if assert.Len(hashDiffs.DeletedKeys, 4, fmt.Sprintf("Expected 4 dropped key, got %d: %s", len(hashDiffs.DeletedKeys), hashDiffs.DeletedKeys)) {
 		sort.Strings(hashDiffs.DeletedKeys)
 		assert.Equal("acceptance_tests.old_key", hashDiffs.DeletedKeys[0])
-		assert.Equal("cf.acceptance-tests.acceptance_tests.old_key", hashDiffs.DeletedKeys[1])
-		assert.Equal("cf.cloud_controller_ng.networks.apps", hashDiffs.DeletedKeys[2])
+		assert.Equal("cf:acceptance-tests:acceptance_tests.old_key", hashDiffs.DeletedKeys[1])
+		assert.Equal("cf:cloud_controller_ng:networks.apps", hashDiffs.DeletedKeys[2])
 		assert.Equal("networks.apps", hashDiffs.DeletedKeys[3])
 	}
 	assert.Len(hashDiffs.ChangedValues, 5)
@@ -521,12 +521,12 @@ func TestDevDiffConfigurations(t *testing.T) {
 		assert.Equal("S3 Access key for staging droplets on AWS installs; Blobstore user for other IaaSs", v[0])
 		assert.Equal("User name used to access internal endpoints of Cloud Controller to upload files when staging", v[1])
 	}
-	v, ok = hashDiffs.ChangedValues["cf.cloud_controller_ng.cc.external_protocol"]
+	v, ok = hashDiffs.ChangedValues["cf:cloud_controller_ng:cc.external_protocol"]
 	if assert.True(ok) {
 		assert.Equal("http", v[0])
 		assert.Equal("https", v[1])
 	}
-	v, ok = hashDiffs.ChangedValues["cf.acceptance-tests.acceptance_tests.fake_key"]
+	v, ok = hashDiffs.ChangedValues["cf:acceptance-tests:acceptance_tests.fake_key"]
 	if assert.True(ok) {
 		assert.Equal("49", v[0])
 		assert.Equal("10", v[1])
@@ -536,7 +536,7 @@ func TestDevDiffConfigurations(t *testing.T) {
 		assert.Equal("Services tests push their apps using diego if enabled", v[0])
 		assert.Equal("App tests push their apps using diego if enabled. Route service tests require this flag to run.", v[1])
 	}
-	v, ok = hashDiffs.ChangedValues["cf.cloud_controller_ng.metron_endpoint.port"]
+	v, ok = hashDiffs.ChangedValues["cf:cloud_controller_ng:metron_endpoint.port"]
 	if assert.True(ok) {
 		assert.Equal("3456", v[0])
 		assert.Equal("3457", v[1])


### PR DESCRIPTION
Sort the hashes by key, and deal with indents.  This makes it easier to compare across releases (reducing false positives caused by runtime differences in hash ordering).

Also, adjust the diff output so it's easier to tell what is a job-specific property.