### PR TITLE
Drop support for kube 1.5 affinity annotations.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,9 @@ docker-deps:
 tools:
 	${GIT_ROOT}/make/tools
 
+show-versions:
+	make/show-versions
+
 # If this fails, try running 'make bindata' and rerun 'make test'
 test:
 	${GIT_ROOT}/make/test

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -96,36 +96,6 @@ func TestGetAffinityBlock(t *testing.T) {
 	assert.Equal(affinity.Get("nodeAffinity").Block(), "if .Values.sizing.role.affinity.nodeAffinity")
 }
 
-func TestGetAffinityAnnotation(t *testing.T) {
-	assert := assert.New(t)
-
-	//
-	// If a pod anti affinity is specified, it should have an annotation
-	//
-	role := deploymentTestLoadRole(assert, "role", "pod-with-valid-pod-anti-affinity.yml")
-	if role == nil {
-		return
-	}
-
-	affinity, err := getAffinityAnnotation(role)
-
-	assert.NoError(err)
-	assert.Equal(affinity, "{\"podAntiAffinity\":{\"preferredDuringSchedulingIgnoredDuringExecution\":[{\"podAffinityTerm\":{\"labelSelector\":{\"matchExpressions\":[{\"key\":\"skiff-role-name\",\"operator\":\"In\",\"values\":[\"role\"]}]},\"topologyKey\":\"beta.kubernetes.io/os\"},\"weight\":100}]}}")
-
-	//
-	// If a pod anti affinity isn't specified, it shouldn't have an annotation
-	//
-	role = deploymentTestLoadRole(assert, "role", "pod-with-no-pod-anti-affinity.yml")
-	if role == nil {
-		return
-	}
-
-	affinity, err = getAffinityAnnotation(role)
-
-	assert.NoError(err)
-	assert.Equal(affinity, "{}")
-}
-
 func createEmptySpec() *helm.Mapping {
 	emptySpec := helm.NewMapping()
 	template := helm.NewMapping()
@@ -162,7 +132,6 @@ func TestAddAffinityRules(t *testing.T) {
 
 	assert.NotNil(spec.Get("template", "spec", "affinity", "podAntiAffinity"))
 	assert.NotNil(spec.Get("template", "spec", "affinity", "nodeAffinity"))
-	assert.NotNil(spec.Get("template", "metadata", "annotations", "scheduler.alpha.kubernetes.io/affinity"))
 	assert.NoError(err)
 
 	//
@@ -209,6 +178,5 @@ func TestAddAffinityRules(t *testing.T) {
 
 	err = addAffinityRules(role, spec, settings)
 	assert.Nil(spec.Get("template", "spec", "affinity", "podAntiAffinity"))
-	assert.NotNil(spec.Get("template", "metadata", "annotations", "scheduler.alpha.kubernetes.io/affinity"))
 	assert.NoError(err)
 }

--- a/make/show-versions
+++ b/make/show-versions
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
+
+. ${GIT_ROOT}/make/include/versioning
+
+cat <<-EOF
+Branch             = ${GIT_BRANCH}
+Tag                = ${GIT_TAG}
+Commits            = ${GIT_COMMITS}
+SHA                = ${GIT_SHA}
+Describe           = ${GIT_DESCRIBE}
+Artifact Name      = ${ARTIFACT_NAME}
+App Version        = ${APP_VERSION}
+EOF


### PR DESCRIPTION
Updated unit tests (also removal).
General add-in of version information target.

https://trello.com/c/3MB6uqby/607-1-deprecate-kube-15-affinity-support-in-fissile