### PR TITLE
Drop auto-creation of stateful sets for roles with volume decls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,10 +46,11 @@ corresponding Kubernetes resource definition
 [usage reference]: ./docs/generated/fissile.md
 
 ## Developing Fissile
-In general, use the default `make` target is preferred before making a
-[pull request].  This will run the tests, as well as the linters.  To manually
-build fissile only, run `make bindata build`.  This will first run the necessary
-code generation before building the binary.
+In general, use of the default `make` target is preferred before
+making a [pull request].  This will run the unit tests, as well as
+various linters.  To manually build fissile only, run
+`make bindata build`.  This will run the necessary code generation
+before building the binary.
 
 [pull request]: https://github.com/SUSE/fissile/pulls
 

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -1062,12 +1062,6 @@ func (f *Fissile) roleIsStateful(role *model.Role) bool {
 	if role.HasTag("clustered") || role.HasTag("indexed") {
 		return true
 	}
-	for _, volume := range role.Run.Volumes {
-		switch volume.Type {
-		case model.VolumeTypePersistent, model.VolumeTypeShared:
-			return true
-		}
-	}
 	return false
 }
 

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -1065,6 +1065,18 @@ func (f *Fissile) roleIsStateful(role *model.Role) bool {
 	return false
 }
 
+// roleHasStorage returns true if a given role uses shared or
+// persistent volumes.
+func (f *Fissile) roleHasStorage(role *model.Role) bool {
+	for _, volume := range role.Run.Volumes {
+		switch volume.Type {
+		case model.VolumeTypePersistent, model.VolumeTypeShared:
+			return true
+		}
+	}
+	return false
+}
+
 func (f *Fissile) generateKubeRoles(settings kube.ExportSettings) error {
 	for _, role := range settings.RoleManifest.Roles {
 		if role.IsDevRole() {
@@ -1106,7 +1118,18 @@ func (f *Fissile) generateKubeRoles(settings kube.ExportSettings) error {
 		case model.RoleTypeBosh:
 			enc := helm.NewEncoder(outputFile)
 
-			if f.roleIsStateful(role) {
+			isStateful := f.roleIsStateful(role)
+			hasStorage := f.roleHasStorage(role)
+
+			if hasStorage && !isStateful {
+				// A role with storage has to be
+				// stateful and was not tagged as
+				// such. Bail out to prevent use of
+				// this broken setup
+				return fmt.Errorf("Role %s uses storage, and is not tagged as indexed, nor as clustered", role.Name)
+			}
+
+			if isStateful {
 				statefulSet, deps, err := kube.NewStatefulSet(role, settings, f)
 				if err != nil {
 					return err

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -35,12 +35,26 @@ cluster that is needed for other purposes.
 [Cloud Foundry Acceptance Tests]: https://github.com/cloudfoundry/cf-acceptance-tests
 
 ### StatefulSet
-Fissile emits a [StatefulSet] under two circumstances.  Any self-clustering
-roles (i.e. any role with the `clustered` tag) will be a StatefulSet, in order
-for each pod to be addressable (so that they can talk to each other).  For
-example, a NATS role would fall under this category.  Secondly, any roles which
-require local storage will be a StatefulSet to take advantage of volume claim
-templates.
+
+Fissile emits a [StatefulSet] under two circumstances.
+
+Any self-clustering roles (i.e. any role with the `clustered` tag)
+will be a StatefulSet, in order for each pod to be addressable (so
+that they can talk to each other). For example, a NATS role would fall
+under this category.
+
+Secondly, any roles tagged as `indexed`. An example of such would be
+the CF role `blobstore`. These are roles which require load balancing
+and need a 0-based, incremented index. To support this fissile creates
+a public service (of type `LoadBalancer`) for indexed roles, providing
+a single point of access to the pods for the role.
+
+Note that both `clustered` and `indexed` roles can take advantage of
+volume claim templates for local storage.
+
+__Attention__: The automatic emission of StatefulSet for roles which
+have volume specifications has been removed. All roles now have to be
+explicitly tagged as described above.
 
 [StatefulSet]: https://kubernetes.io/docs/resources-reference/v1.6/#statefulset-v1beta1-apps
 

--- a/docs/kubernetes.md
+++ b/docs/kubernetes.md
@@ -40,14 +40,14 @@ Fissile emits a [StatefulSet] under two circumstances.
 
 Any self-clustering roles (i.e. any role with the `clustered` tag)
 will be a StatefulSet, in order for each pod to be addressable (so
-that they can talk to each other). For example, a NATS role would fall
-under this category.
+that they can talk to each other). For example, a `doppler` role would
+fall under this category.
 
 Secondly, any roles tagged as `indexed`. An example of such would be
-the CF role `blobstore`. These are roles which require load balancing
-and need a 0-based, incremented index. To support this fissile creates
-a public service (of type `LoadBalancer`) for indexed roles, providing
-a single point of access to the pods for the role.
+the CF role `nats`. These are roles which require load balancing and
+need a 0-based, incremented index. To support this fissile creates a
+public service (of type `LoadBalancer`) for indexed roles, providing a
+single point of access to the pods for the role.
 
 Note that both `clustered` and `indexed` roles can take advantage of
 volume claim templates for local storage.

--- a/make/clean
+++ b/make/clean
@@ -2,6 +2,10 @@
 
 set -o errexit -o nounset
 
+. make/include/colors.sh
+
+printf "%b==> Cleaning %b\n" "${OK_COLOR}" "${ERROR_COLOR}"
+
 GIT_ROOT=${GIT_ROOT:-$(git rev-parse --show-toplevel)}
 
 rm -rf ${GIT_ROOT}/build
@@ -12,3 +16,5 @@ rm -f ${GIT_ROOT}/scripts/dockerfiles/dockerfiles.go
 rm -f ${GIT_ROOT}/scripts/templates/transformations.go
 rm -f ${GIT_ROOT}/scripts/configgin/configgin.go
 rm -rf ${GIT_ROOT}/scripts/configgin/output
+
+printf "%b" "${NO_COLOR}"


### PR DESCRIPTION
 This forces the explicit use of tags at roles to trigger their creation.
Further tweaked make, announce cleaning like all the other ops.

https://trello.com/c/0zylWw07/606-2-fissile-statefulsets-should-be-explicitly-defined

Dependent: https://github.com/SUSE/scf/pull/1456
Dependent: https://github.com/SUSE/uaa-fissile-release/pull/94
