### PR TITLE
Add support for multi-containers per pod

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -1079,7 +1079,7 @@ func (f *Fissile) roleHasStorage(role *model.Role) bool {
 
 func (f *Fissile) generateKubeRoles(settings kube.ExportSettings) error {
 	for _, role := range settings.RoleManifest.Roles {
-		if role.IsDevRole() {
+		if role.IsDevRole() || role.IsColocatedContainerRole() {
 			continue
 		}
 		if settings.CreateHelmChart && role.Run.FlightStage == model.FlightStageManual {

--- a/test-assets/role-manifests/colocated-containers-with-missing-role.yml
+++ b/test-assets/role-manifests/colocated-containers-with-missing-role.yml
@@ -1,0 +1,13 @@
+---
+roles:
+- name: main-role
+  scripts: ["myrole.sh"]
+  run:
+    memory: 1
+  jobs:
+  - name: new_hostname
+    release_name: tor
+  - name: tor
+    release_name: tor
+  colocated_containers:
+  - to-be-colocated-typo

--- a/test-assets/role-manifests/colocated-containers-with-port-collision.yml
+++ b/test-assets/role-manifests/colocated-containers-with-port-collision.yml
@@ -1,0 +1,42 @@
+---
+roles:
+- name: main-role
+  scripts: ["myrole.sh"]
+  run:
+    memory: 1
+    exposed-ports:
+    - name: http
+      protocol: TCP
+      internal: 8080
+      external: 80
+    - name: https
+      protocol: TCP
+      internal: 9443
+      external: 443
+    - name: range
+      protocol: TCP
+      internal: 10000-11000
+  tags:
+  - clustered
+  jobs:
+  - name: new_hostname
+    release_name: tor
+  - name: tor
+    release_name: tor
+  colocated_containers:
+  - to-be-colocated
+
+- name: to-be-colocated
+  type: colocated-container
+  jobs:
+  - name: ntpd
+    release_name: ntp
+  run:
+    memory: 1
+    exposed-ports:
+    - name: time-srv
+      protocol: TCP
+      internal: 80
+    - name: debug-port
+      protocol: TCP
+      internal: 10443

--- a/test-assets/role-manifests/colocated-containers-with-unused-role.yml
+++ b/test-assets/role-manifests/colocated-containers-with-unused-role.yml
@@ -1,0 +1,29 @@
+---
+roles:
+- name: main-role
+  scripts: ["myrole.sh"]
+  run:
+    memory: 1
+  jobs:
+  - name: new_hostname
+    release_name: tor
+  - name: tor
+    release_name: tor
+  colocated_containers:
+  - to-be-colocated
+
+- name: to-be-colocated
+  type: colocated-container
+  jobs:
+  - name: ntpd
+    release_name: ntp
+  run:
+    memory: 1
+
+- name: orphaned
+  type: colocated-container
+  jobs:
+  - name: ntpd
+    release_name: ntp
+  run:
+    memory: 1

--- a/test-assets/role-manifests/colocated-containers.yml
+++ b/test-assets/role-manifests/colocated-containers.yml
@@ -1,0 +1,21 @@
+---
+roles:
+- name: main-role
+  scripts: ["myrole.sh"]
+  run:
+    memory: 1
+  jobs:
+  - name: new_hostname
+    release_name: tor
+  - name: tor
+    release_name: tor
+  colocated_containers:
+  - to-be-colocated
+
+- name: to-be-colocated
+  type: colocated-container
+  jobs:
+  - name: ntpd
+    release_name: ntp
+  run:
+    memory: 1


### PR DESCRIPTION
Like discussed in #340 and in a call with @viovanov, we would like to propose the following:
- Add a new `type` of role called `colocated-container` which is only intended to be used by another role and will not end up as a template YAML itself.
- Add a new list of role names called `colocated_container` in the role, which contains the name references to `colocated-container` roles.

A series of validation tests were added:
- Check for unused `colocated-container` roles
- Check for `colocated-container` not existing
- Check if a role and its `colocated-container` roles have port collisions

**One important point** about `monit`: In this proposal we avoided adding use case specific logic for `monit` into `fissile`. Each `colocated-container` role using `monit` has to specify a `monit` port that is sure not to collide with the main role or any other `colocated-container` of that main role. We felt this is better suited in the README about this feature. If this is not a desired behavior, please let us know.

We would be happy to provide further documentation on that feature, if you could point us to the best spot for that.

This would fix #340.

Signed-off-by: Enrique Eduardo Encalada Olivas <encalada@de.ibm.com>