### PR TITLE
Rework pod management

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -1079,7 +1079,7 @@ func (f *Fissile) roleHasStorage(role *model.Role) bool {
 
 func (f *Fissile) generateKubeRoles(settings kube.ExportSettings) error {
 	for _, role := range settings.RoleManifest.Roles {
-		if role.IsDevRole() || role.IsColocatedContainerRole() {
+		if role.IsColocatedContainerRole() {
 			continue
 		}
 		if settings.CreateHelmChart && role.Run.FlightStage == model.FlightStageManual {

--- a/app/fissile.go
+++ b/app/fissile.go
@@ -1034,7 +1034,7 @@ func (f *Fissile) writeHelmNode(dirName, fileName string, node helm.Node) error 
 }
 
 func (f *Fissile) generateBoshTaskRole(outputFile *os.File, role *model.Role, settings kube.ExportSettings) error {
-	if role.IsStopOnFailureRole() {
+	if role.HasTag(model.RoleTagStopOnFailure) {
 		pod, err := kube.NewPod(role, settings, f)
 		if err != nil {
 			return err
@@ -1059,7 +1059,7 @@ func (f *Fissile) generateBoshTaskRole(outputFile *os.File, role *model.Role, se
 
 // roleIsStateful returns true if a given role needs to be a StatefulSet
 func (f *Fissile) roleIsStateful(role *model.Role) bool {
-	if role.HasTag("clustered") || role.HasTag("indexed") {
+	if role.HasTag(model.RoleTagClustered) || role.HasTag(model.RoleTagIndexed) {
 		return true
 	}
 	return false

--- a/builder/role_image.go
+++ b/builder/role_image.go
@@ -188,6 +188,7 @@ func (r *RoleImageBuilder) NewDockerPopulator(role *model.Role, baseImageName st
 		}
 		err = util.WriteToTarStream(tarWriter, runScriptContents, tar.Header{
 			Name: "root/opt/fissile/run.sh",
+			Mode: 0755,
 		})
 		if err != nil {
 			return err
@@ -199,6 +200,7 @@ func (r *RoleImageBuilder) NewDockerPopulator(role *model.Role, baseImageName st
 		}
 		err = util.WriteToTarStream(tarWriter, preStopScriptContents, tar.Header{
 			Name: "root/opt/fissile/pre-stop.sh",
+			Mode: 0755,
 		})
 		if err != nil {
 			return err
@@ -210,6 +212,19 @@ func (r *RoleImageBuilder) NewDockerPopulator(role *model.Role, baseImageName st
 		}
 		err = util.WriteToTarStream(tarWriter, jobsConfigContents, tar.Header{
 			Name: "root/opt/fissile/job_config.json",
+		})
+		if err != nil {
+			return err
+		}
+
+		// Copy readiness probe script
+		readinessProbeScriptContents, err := r.generateRunScript(role, "readiness-probe.sh")
+		if err != nil {
+			return err
+		}
+		err = util.WriteToTarStream(tarWriter, readinessProbeScriptContents, tar.Header{
+			Name: "root/opt/fissile/readiness-probe.sh",
+			Mode: 0755,
 		})
 		if err != nil {
 			return err

--- a/builder/role_image_test.go
+++ b/builder/role_image_test.go
@@ -233,14 +233,17 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 		desc     string
 		typeflag byte // default to TypeRegA
 		keep     bool // Hold for extra examination after
+		mode     int64
 	}{
 		"Dockerfile":                                              {desc: "Dockerfile"},
 		"root/opt/fissile/share/doc/tor/LICENSE":                  {desc: "release license file"},
-		"root/opt/fissile/run.sh":                                 {desc: "run script"},
+		"root/opt/fissile/run.sh":                                 {desc: "run script", mode: 0755},
+		"root/opt/fissile/pre-stop.sh":                            {desc: "pre-stop script", mode: 0755},
+		"root/opt/fissile/readiness-probe.sh":                     {desc: "readiness probe script", mode: 0755},
 		"root/opt/fissile/startup/myrole.sh":                      {desc: "role specific startup script"},
 		"root/var/vcap/jobs-src/tor/monit":                        {desc: "job monit file"},
 		"root/var/vcap/jobs-src/tor/templates/bin/monit_debugger": {desc: "job template file"},
-		"root/var/vcap/jobs-src/tor/config_spec.json":             {desc: "tor config spec", keep: true},
+		"root/var/vcap/jobs-src/tor/config_spec.json":             {desc: "tor config spec", keep: true, mode: 0644},
 		"root/var/vcap/jobs-src/new_hostname/config_spec.json":    {desc: "new_hostname config spec", keep: true},
 		"root/var/vcap/packages/tor":                              {desc: "package symlink", typeflag: tar.TypeSymlink, keep: true},
 		"root/var/vcap/jobs-src/tor/job.MF":                       {desc: "job manifest file", typeflag: TypeMissing},
@@ -283,6 +286,9 @@ func TestGenerateRoleImageDockerfileDir(t *testing.T) {
 				continue
 			}
 			assert.Equal(info.typeflag, header.Typeflag, "Unexpected type for item %s", header.Name)
+			if info.mode != 0 {
+				assert.Equal(info.mode, header.Mode, "Unexpected file permissions for item %s", header.Name)
+			}
 			if info.keep {
 				if header.Typeflag == tar.TypeSymlink || header.Typeflag == tar.TypeLink {
 					actual[header.Name] = []byte(header.Linkname)

--- a/helm/config.go
+++ b/helm/config.go
@@ -593,3 +593,36 @@ func (enc *Encoder) writeNode(node Node, prefix *string, label string, emptyLine
 		enc.pendingNewline = emptyLines
 	}
 }
+
+// MakeBasicValues returns a Mapping with the default values that do not depend
+// on any configuration.  This is exported so the tests from other packages can
+// access them.
+func MakeBasicValues() *Mapping {
+	return NewMapping(
+		"kube", NewMapping(
+			"external_ips", NewList(),
+			"secrets_generation_counter", NewNode(1, Comment("Increment this counter to rotate all generated secrets")),
+			"storage_class", NewMapping("persistent", "persistent", "shared", "shared"),
+			"hostpath_available", NewNode(false, Comment("Whether HostPath volume mounts are available")),
+			"registry", NewMapping(
+				"hostname", "docker.io",
+				"username", "",
+				"password", ""),
+			"organization", "",
+			"auth", nil),
+		"config", NewMapping(
+			"HA", NewNode(false, Comment("Flag to activate high-availability mode")),
+			"memory", NewNode(NewMapping(
+				"requests", NewNode(false, Comment("Flag to activate memory requests")),
+				"limits", NewNode(false, Comment("Flag to activate memory limits")),
+			), Comment("Global memory configuration")),
+			"cpu", NewNode(NewMapping(
+				"requests", NewNode(false, Comment("Flag to activate cpu requests")),
+				"limits", NewNode(false, Comment("Flag to activate cpu limits")),
+			), Comment("Global CPU configuration"))),
+		"env", NewMapping(),
+		"sizing", NewMapping(),
+		"secrets", NewMapping(),
+		"services", NewMapping(
+			"loadbalanced", false))
+}

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -16,7 +16,7 @@ func NewDeployment(role *model.Role, settings ExportSettings, grapher util.Model
 		return nil, nil, err
 	}
 
-	svc, err := NewClusterIPServiceList(role, ClusterIPPrivate, settings)
+	svc, err := NewServiceList(role, false, settings)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -16,7 +16,7 @@ func NewDeployment(role *model.Role, settings ExportSettings, grapher util.Model
 		return nil, nil, err
 	}
 
-	svc, err := NewClusterIPServiceList(role, false, true, settings)
+	svc, err := NewClusterIPServiceList(role, ClusterIPPrivate, settings)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -256,7 +256,9 @@ func TestNewDeploymentHelm(t *testing.T) {
 							livenessProbe: ~
 							name: "role"
 							ports: ~
-							readinessProbe: ~
+							readinessProbe:
+								exec:
+									command: [ /opt/fissile/readiness-probe.sh ]
 							resources: ~
 							securityContext:
 								capabilities:

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -536,35 +536,75 @@ func getContainerReadinessProbe(role *model.Role) (helm.Node, error) {
 		return nil, nil
 	}
 
-	var probe *helm.Mapping
-	if role.Run.HealthCheck != nil && role.Run.HealthCheck.Readiness != nil {
-		var complete bool
-		var err error
-		probe, complete, err = configureContainerProbe(role, "readiness", role.Run.HealthCheck.Readiness)
-		if complete || err != nil {
-			return probe, err
+	switch role.Type {
+	case model.RoleTypeBosh:
+		// For BOSH roles, we use the built-in readiness script
+		probe := helm.NewMapping()
+		probeCommand := helm.NewList()
+		if role.Run.ActivePassiveProbe != "" {
+			probeCommand.Add("/usr/bin/env",
+				"FISSILE_ACTIVE_PASSIVE_PROBE="+role.Run.ActivePassiveProbe)
 		}
-	}
-	if role.Type != model.RoleTypeBosh {
-		return nil, nil
-	}
-
-	var readinessPort *model.RoleRunExposedPort
-	for _, port := range role.Run.ExposedPorts {
-		if port.Protocol == "TCP" {
-			readinessPort = port
-			break
+		probeCommand.Add("/opt/fissile/readiness-probe.sh")
+		if role.Run.HealthCheck != nil && role.Run.HealthCheck.Readiness != nil {
+			roleProbe := role.Run.HealthCheck.Readiness
+			for _, command := range roleProbe.Command {
+				probeCommand.Add(command)
+			}
+			// addParam is a helper to avoid adding a parameter for a zero value
+			addParam := func(name string, value int) {
+				if value != 0 {
+					probe.Add(name, value)
+				}
+			}
+			addParam("initialDelaySeconds", roleProbe.InitialDelay)
+			addParam("timeoutSeconds", roleProbe.Timeout)
+			addParam("periodSeconds", roleProbe.Period)
+			addParam("successThreshold", roleProbe.SuccessThreshold)
+			addParam("failureThreshold", roleProbe.FailureThreshold)
 		}
-	}
-	if readinessPort == nil {
-		return nil, nil
-	}
+		probe.Add("exec", helm.NewMapping("command", probeCommand))
+		return probe.Sort(), nil
 
-	if probe == nil {
-		probe = helm.NewMapping()
+	case model.RoleTypeBoshTask:
+		// Tasks have no readiness probes
+		return nil, nil
+
+	case model.RoleTypeDocker:
+		var probe *helm.Mapping
+		if role.Run.HealthCheck != nil && role.Run.HealthCheck.Readiness != nil {
+			var complete bool
+			var err error
+			probe, complete, err = configureContainerProbe(role, "readiness", role.Run.HealthCheck.Readiness)
+			if complete || err != nil {
+				return probe.Sort(), err
+			}
+		}
+		var readinessPort *model.RoleRunExposedPort
+		for _, port := range role.Run.ExposedPorts {
+			if port.Protocol == "TCP" {
+				readinessPort = port
+				break
+			}
+		}
+		if readinessPort == nil {
+			return nil, nil
+		}
+
+		if probe == nil {
+			probe = helm.NewMapping()
+		}
+		probe.Add("tcpSocket", helm.NewMapping("port", readinessPort.InternalPort))
+		return probe.Sort(), nil
+
+	case model.RoleTypeColocatedContainer:
+		// Colocated containers have no readiness probes
+		return nil, nil
+
+	default:
+		// This should have been caught earlier, when we loaded the role manifest
+		panic(fmt.Sprintf("Unexpected role type %s in %s readiness probe", role.Type, role.Name))
 	}
-	probe.Add("tcpSocket", helm.NewMapping("port", readinessPort.InternalPort))
-	return probe.Sort(), nil
 }
 
 func configureContainerProbe(role *model.Role, probeName string, roleProbe *model.HealthProbe) (*helm.Mapping, bool, error) {

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -1294,85 +1293,116 @@ func TestPodGetContainerLivenessProbe(t *testing.T) {
 
 func TestPodGetContainerReadinessProbe(t *testing.T) {
 	t.Parallel()
-	assert := assert.New(t)
-	role := podTemplateTestLoadRole(assert)
-	if role == nil {
-		return
-	}
 
-	samples := []Sample{
+	samples := []struct {
+		desc  string
+		input *model.HealthProbe
+		// We have different expected behaviours for docker roles (supporting
+		// all three probe types) and BOSH roles (only commands are allowed)
+		dockerExpected string
+		dockerError    string
+		boshExpected   string
+		boshError      string
+	}{
 		{
-			desc:     "No probe",
-			input:    nil,
-			expected: `---`,
+			desc:           "No probe",
+			input:          nil,
+			dockerExpected: ``,
+			boshExpected: `---
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "Port probe",
 			input: &model.HealthProbe{
 				Port: 1234,
 			},
-			expected: `---
+			dockerExpected: `---
 				tcpSocket:
 					port: 1234`,
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "Command probe",
 			input: &model.HealthProbe{
 				Command: []string{"rm", "-rf", "--no-preserve-root", "/"},
 			},
-			expected: `---
+			dockerExpected: `---
 				exec:
 					command: [ rm, "-rf", "--no-preserve-root", /]`,
+			boshExpected: `---
+				exec:
+					# Note that this is being interpreted as five separate commands
+					command: [ /opt/fissile/readiness-probe.sh, rm, "-rf", "--no-preserve-root", /]`,
 		},
 		{
 			desc: "URL probe (simple)",
 			input: &model.HealthProbe{
 				URL: "http://example.com/path",
 			},
-			expected: `---
+			dockerExpected: `---
 				httpGet:
 					scheme: HTTP
 					host:   "example.com"
 					port:   80
 					path:   "/path"`,
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "URL probe (custom port)",
 			input: &model.HealthProbe{
 				URL: "https://example.com:1234/path",
 			},
-			expected: `---
+			dockerExpected: `---
 				httpGet:
 					scheme: HTTPS
 					host:   "example.com"
 					port:   1234
 					path:   "/path"`,
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "URL probe (Invalid scheme)",
 			input: &model.HealthProbe{
 				URL: "file:///etc/shadow",
 			},
-			err: "Health check for myrole has unsupported URI scheme \"file\"",
+			dockerError: "Health check for myrole has unsupported URI scheme \"file\"",
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "URL probe (query)",
 			input: &model.HealthProbe{
 				URL: "http://example.com/path?query#hash",
 			},
-			expected: `---
+			dockerExpected: `---
 				httpGet:
 					scheme: HTTP
 					host:   "example.com"
 					port:   80
 					path:   "/path?query"`,
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "URL probe (auth)",
 			input: &model.HealthProbe{
 				URL: "http://user:pass@example.com/path",
 			},
-			expected: `---
+			dockerExpected: `---
 				httpGet:
 					scheme: HTTP
 					host:   "example.com"
@@ -1381,6 +1411,10 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 					httpHeaders:
 					-	name:  Authorization
 						value: dXNlcjpwYXNz`,
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "URL probe (custom headers)",
@@ -1388,7 +1422,7 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 				URL:     "http://example.com/path",
 				Headers: map[string]string{"x-header": "some value"},
 			},
-			expected: `---
+			dockerExpected: `---
 				httpGet:
 					scheme: HTTP
 					host:   "example.com"
@@ -1397,31 +1431,47 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 					httpHeaders:
 					-	name:  "X-Header"
 						value: "some value"`,
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "URL probe (invalid URL)",
 			input: &model.HealthProbe{
 				URL: "://",
 			},
-			err: "Invalid readiness URL health check for myrole: parse ://: missing protocol scheme",
+			dockerError: "Invalid readiness URL health check for myrole: parse ://: missing protocol scheme",
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "URL probe (invalid port)",
 			input: &model.HealthProbe{
 				URL: "http://example.com:port_number/",
 			},
-			err: "Failed to get URL port for health check for myrole: invalid host \"example.com:port_number\"",
+			dockerError: "Failed to get URL port for health check for myrole: invalid host \"example.com:port_number\"",
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "URL probe (localhost)",
 			input: &model.HealthProbe{
 				URL: "http://container-ip/path",
 			},
-			expected: `---
+			dockerExpected: `---
 				httpGet:
 					scheme: HTTP
 					port:   80
 					path:   "/path"`,
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "Port probe, readiness timeout",
@@ -1429,10 +1479,15 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 				Port:    1234,
 				Timeout: 20,
 			},
-			expected: `---
+			dockerExpected: `---
 				timeoutSeconds: 20
 				tcpSocket:
 					port: 1234`,
+			boshExpected: `---
+				# This would have failed validation
+				timeoutSeconds: 20
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "Command probe, readiness timeout",
@@ -1440,10 +1495,15 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 				Command: []string{"rm", "-rf", "--no-preserve-root", "/"},
 				Timeout: 20,
 			},
-			expected: `---
+			dockerExpected: `---
 				timeoutSeconds: 20
 				exec:
 					command: [ rm, "-rf", "--no-preserve-root", /]`,
+			boshExpected: `---
+				timeoutSeconds: 20
+				exec:
+					# This is interpreted as five separate commands
+					command: [ /opt/fissile/readiness-probe.sh, rm, "-rf", "--no-preserve-root", /]`,
 		},
 		{
 			desc: "URL probe (simple), readiness timeout",
@@ -1451,65 +1511,156 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 				URL:     "http://example.com/path",
 				Timeout: 20,
 			},
-			expected: `---
+			dockerExpected: `---
 				timeoutSeconds: 20
 				httpGet:
 					scheme: HTTP
 					host:   "example.com"
 					port:   80
 					path:   "/path"`,
+			boshExpected: `---
+				# This would have failed validation
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh ]`,
 		},
 		{
 			desc: "Initial Delay Seconds",
 			input: &model.HealthProbe{
 				InitialDelay: 22,
-				Port:         2289,
+				Command:      []string{"/bin/true"},
 			},
-			expected: `---
+			dockerExpected: `---
 				initialDelaySeconds: 22
-				tcpSocket:
-					port: 2289`,
+				exec:
+					command: [ /bin/true ]`,
+			boshExpected: `---
+				initialDelaySeconds: 22
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh, /bin/true ]`,
 		},
 		{
 			desc: "Success Threshold",
 			input: &model.HealthProbe{
 				SuccessThreshold: 20,
-				Port:             2289,
+				Command:          []string{"/bin/true"},
 			},
-			expected: `---
+			dockerExpected: `---
 				successThreshold: 20
-				tcpSocket:
-					port: 2289`,
+				exec:
+					command: [ /bin/true ]`,
+			boshExpected: `---
+				successThreshold: 20
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh, /bin/true ]`,
 		},
 		{
 			desc: "Failure Threshold",
 			input: &model.HealthProbe{
 				FailureThreshold: 20,
-				Port:             2289,
+				Command:          []string{"/bin/true"},
 			},
-			expected: `---
+			dockerExpected: `---
 				failureThreshold: 20
-				tcpSocket:
-					port: 2289`,
+				exec:
+					command: [ /bin/true ]`,
+			boshExpected: `---
+				failureThreshold: 20
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh, /bin/true ]`,
 		},
 		{
 			desc: "Period Seconds",
 			input: &model.HealthProbe{
-				Period: 20,
-				Port:   2289,
+				Period:  20,
+				Command: []string{"/bin/true"},
 			},
-			expected: `---
+			dockerExpected: `---
 				periodSeconds: 20
-				tcpSocket:
-					port: 2289`,
+				exec:
+					command: [ /bin/true ]`,
+			boshExpected: `---
+				periodSeconds: 20
+				exec:
+					command: [ /opt/fissile/readiness-probe.sh, /bin/true ]`,
 		},
 	}
 
 	for _, sample := range samples {
-		probe, _ := sample.input.(*model.HealthProbe)
-		role.Run.HealthCheck = &model.HealthCheck{Readiness: probe}
-		actual, err := getContainerReadinessProbe(role)
-		sample.check(t, actual, err)
+		t.Run(sample.desc, func(t *testing.T) {
+			t.Parallel()
+			t.Run("docker", func(t *testing.T) {
+				t.Parallel()
+				role := podTemplateTestLoadRole(assert.New(t))
+				require.NotNil(t, role)
+				role.Run.HealthCheck = &model.HealthCheck{Readiness: sample.input}
+				role.Type = model.RoleTypeDocker
+				probe, err := getContainerReadinessProbe(role)
+				if sample.dockerError != "" {
+					assert.EqualError(t, err, sample.dockerError)
+					return
+				}
+				require.NoError(t, err)
+				if sample.dockerExpected == "" {
+					assert.Nil(t, probe)
+					return
+				}
+				require.NotNil(t, probe, "No error getting readiness probe but it was nil")
+				t.Run("kube", func(t *testing.T) {
+					t.Parallel()
+					actual, err := testhelpers.RoundtripKube(probe)
+					if assert.NoError(t, err) {
+						// We use subset testing here because we don't want to bother with the
+						// default timeout lengths
+						testhelpers.IsYAMLSubsetString(assert.New(t), sample.dockerExpected, actual)
+					}
+				})
+				t.Run("helm", func(t *testing.T) {
+					t.Parallel()
+					actual, err := testhelpers.RoundtripNode(probe, map[string]interface{}{})
+					if assert.NoError(t, err) {
+						// We use subset testing here because we don't want to bother with the
+						// default timeout lengths
+						testhelpers.IsYAMLSubsetString(assert.New(t), sample.dockerExpected, actual)
+					}
+				})
+			})
+			t.Run("bosh", func(t *testing.T) {
+				t.Parallel()
+				role := podTemplateTestLoadRole(assert.New(t))
+				require.NotNil(t, role)
+				role.Run.HealthCheck = &model.HealthCheck{Readiness: sample.input}
+				role.Type = model.RoleTypeBosh
+				probe, err := getContainerReadinessProbe(role)
+				if sample.boshError != "" {
+					assert.EqualError(t, err, sample.boshError)
+					return
+				}
+				require.NoError(t, err)
+				if sample.boshExpected == "" {
+					assert.Nil(t, probe)
+					return
+				}
+				require.NotNil(t, probe, "No error getting readiness probe but it was nil")
+				t.Run("kube", func(t *testing.T) {
+					t.Parallel()
+					actual, err := testhelpers.RoundtripKube(probe)
+					if assert.NoError(t, err) {
+						// We use subset testing here because we don't want to bother with the
+						// default timeout lengths
+						testhelpers.IsYAMLSubsetString(assert.New(t), sample.boshExpected, actual)
+					}
+				})
+				t.Run("helm", func(t *testing.T) {
+					t.Parallel()
+					actual, err := testhelpers.RoundtripNode(probe, map[string]interface{}{})
+					if assert.NoError(t, err) {
+						// We use subset testing here because we don't want to bother with the
+						// default timeout lengths
+						testhelpers.IsYAMLSubsetString(assert.New(t), sample.boshExpected, actual)
+					}
+				})
+			})
+		})
 	}
 }
 

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1294,7 +1294,7 @@ func TestPodGetContainerLivenessProbe(t *testing.T) {
 func TestPodGetContainerReadinessProbe(t *testing.T) {
 	t.Parallel()
 
-	samples := []struct {
+	type sampleStruct struct {
 		desc  string
 		input *model.HealthProbe
 		// We have different expected behaviours for docker roles (supporting
@@ -1303,7 +1303,9 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 		dockerError    string
 		boshExpected   string
 		boshError      string
-	}{
+	}
+
+	samples := []sampleStruct{
 		{
 			desc:           "No probe",
 			input:          nil,
@@ -1586,81 +1588,83 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 	}
 
 	for _, sample := range samples {
-		t.Run(sample.desc, func(t *testing.T) {
-			t.Parallel()
-			t.Run("docker", func(t *testing.T) {
+		func(sample sampleStruct) {
+			t.Run(sample.desc, func(t *testing.T) {
 				t.Parallel()
-				role := podTemplateTestLoadRole(assert.New(t))
-				require.NotNil(t, role)
-				role.Run.HealthCheck = &model.HealthCheck{Readiness: sample.input}
-				role.Type = model.RoleTypeDocker
-				probe, err := getContainerReadinessProbe(role)
-				if sample.dockerError != "" {
-					assert.EqualError(t, err, sample.dockerError)
-					return
-				}
-				require.NoError(t, err)
-				if sample.dockerExpected == "" {
-					assert.Nil(t, probe)
-					return
-				}
-				require.NotNil(t, probe, "No error getting readiness probe but it was nil")
-				t.Run("kube", func(t *testing.T) {
+				t.Run("docker", func(t *testing.T) {
 					t.Parallel()
-					actual, err := testhelpers.RoundtripKube(probe)
-					if assert.NoError(t, err) {
-						// We use subset testing here because we don't want to bother with the
-						// default timeout lengths
-						testhelpers.IsYAMLSubsetString(assert.New(t), sample.dockerExpected, actual)
+					role := podTemplateTestLoadRole(assert.New(t))
+					require.NotNil(t, role)
+					role.Run.HealthCheck = &model.HealthCheck{Readiness: sample.input}
+					role.Type = model.RoleTypeDocker
+					probe, err := getContainerReadinessProbe(role)
+					if sample.dockerError != "" {
+						assert.EqualError(t, err, sample.dockerError)
+						return
 					}
+					require.NoError(t, err)
+					if sample.dockerExpected == "" {
+						assert.Nil(t, probe)
+						return
+					}
+					require.NotNil(t, probe, "No error getting readiness probe but it was nil")
+					t.Run("kube", func(t *testing.T) {
+						t.Parallel()
+						actual, err := testhelpers.RoundtripKube(probe)
+						if assert.NoError(t, err) {
+							// We use subset testing here because we don't want to bother with the
+							// default timeout lengths
+							testhelpers.IsYAMLSubsetString(assert.New(t), sample.dockerExpected, actual)
+						}
+					})
+					t.Run("helm", func(t *testing.T) {
+						t.Parallel()
+						actual, err := testhelpers.RoundtripNode(probe, map[string]interface{}{})
+						if assert.NoError(t, err) {
+							// We use subset testing here because we don't want to bother with the
+							// default timeout lengths
+							testhelpers.IsYAMLSubsetString(assert.New(t), sample.dockerExpected, actual)
+						}
+					})
 				})
-				t.Run("helm", func(t *testing.T) {
+				t.Run("bosh", func(t *testing.T) {
 					t.Parallel()
-					actual, err := testhelpers.RoundtripNode(probe, map[string]interface{}{})
-					if assert.NoError(t, err) {
-						// We use subset testing here because we don't want to bother with the
-						// default timeout lengths
-						testhelpers.IsYAMLSubsetString(assert.New(t), sample.dockerExpected, actual)
+					role := podTemplateTestLoadRole(assert.New(t))
+					require.NotNil(t, role)
+					role.Run.HealthCheck = &model.HealthCheck{Readiness: sample.input}
+					role.Type = model.RoleTypeBosh
+					probe, err := getContainerReadinessProbe(role)
+					if sample.boshError != "" {
+						assert.EqualError(t, err, sample.boshError)
+						return
 					}
+					require.NoError(t, err)
+					if sample.boshExpected == "" {
+						assert.Nil(t, probe)
+						return
+					}
+					require.NotNil(t, probe, "No error getting readiness probe but it was nil")
+					t.Run("kube", func(t *testing.T) {
+						t.Parallel()
+						actual, err := testhelpers.RoundtripKube(probe)
+						if assert.NoError(t, err) {
+							// We use subset testing here because we don't want to bother with the
+							// default timeout lengths
+							testhelpers.IsYAMLSubsetString(assert.New(t), sample.boshExpected, actual)
+						}
+					})
+					t.Run("helm", func(t *testing.T) {
+						t.Parallel()
+						actual, err := testhelpers.RoundtripNode(probe, map[string]interface{}{})
+						if assert.NoError(t, err) {
+							// We use subset testing here because we don't want to bother with the
+							// default timeout lengths
+							testhelpers.IsYAMLSubsetString(assert.New(t), sample.boshExpected, actual)
+						}
+					})
 				})
 			})
-			t.Run("bosh", func(t *testing.T) {
-				t.Parallel()
-				role := podTemplateTestLoadRole(assert.New(t))
-				require.NotNil(t, role)
-				role.Run.HealthCheck = &model.HealthCheck{Readiness: sample.input}
-				role.Type = model.RoleTypeBosh
-				probe, err := getContainerReadinessProbe(role)
-				if sample.boshError != "" {
-					assert.EqualError(t, err, sample.boshError)
-					return
-				}
-				require.NoError(t, err)
-				if sample.boshExpected == "" {
-					assert.Nil(t, probe)
-					return
-				}
-				require.NotNil(t, probe, "No error getting readiness probe but it was nil")
-				t.Run("kube", func(t *testing.T) {
-					t.Parallel()
-					actual, err := testhelpers.RoundtripKube(probe)
-					if assert.NoError(t, err) {
-						// We use subset testing here because we don't want to bother with the
-						// default timeout lengths
-						testhelpers.IsYAMLSubsetString(assert.New(t), sample.boshExpected, actual)
-					}
-				})
-				t.Run("helm", func(t *testing.T) {
-					t.Parallel()
-					actual, err := testhelpers.RoundtripNode(probe, map[string]interface{}{})
-					if assert.NoError(t, err) {
-						// We use subset testing here because we don't want to bother with the
-						// default timeout lengths
-						testhelpers.IsYAMLSubsetString(assert.New(t), sample.boshExpected, actual)
-					}
-				})
-			})
-		})
+		}(sample)
 	}
 }
 

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1021,7 +1021,7 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserRequired(t *testing.T) {
 		t.Parallel()
 		_, err := testhelpers.RenderNode(ev, nil)
 		assert.EqualError(err,
-			`template: :7:62: executing "" at <.Values.env.SOMETHIN...>: can't evaluate field SOMETHING in type interface {}`)
+			`template: :7:12: executing "" at <required "SOMETHING ...>: error calling required: SOMETHING configuration missing`)
 	})
 
 	t.Run("Undefined", func(t *testing.T) {

--- a/kube/secret_test.go
+++ b/kube/secret_test.go
@@ -175,7 +175,7 @@ func TestMakeSecretsHelm(t *testing.T) {
 
 		_, err := testhelpers.RenderNode(secret, nil)
 		assert.EqualError(err,
-			`template: :6:61: executing "" at <.Values.secrets.cons...>: can't evaluate field const in type interface {}`)
+			`template: :6:12: executing "" at <required "secrets.co...>: error calling required: secrets.const has not been set`)
 	})
 
 	t.Run("Undefined", func(t *testing.T) {

--- a/kube/service.go
+++ b/kube/service.go
@@ -33,15 +33,15 @@ func NewServiceList(role *model.Role, clustering bool, settings ExportSettings) 
 		if svc != nil {
 			items = append(items, svc)
 		}
+	}
 
-		// Create public service
-		svc, err = newService(role, newServiceTypePublic, settings)
-		if err != nil {
-			return nil, err
-		}
-		if svc != nil {
-			items = append(items, svc)
-		}
+	// Create public service
+	svc, err := newService(role, newServiceTypePublic, settings)
+	if err != nil {
+		return nil, err
+	}
+	if svc != nil {
+		items = append(items, svc)
 	}
 
 	if len(items) == 0 {

--- a/kube/service.go
+++ b/kube/service.go
@@ -7,11 +7,20 @@ import (
 	"github.com/SUSE/fissile/model"
 )
 
+// ClusterIPServiceFlag describes the kinds of services to enable
+type ClusterIPServiceFlag int
+
+// Valid values for ClusterIPServiceFlag
+const (
+	ClusterIPHeadless = ClusterIPServiceFlag(1 << iota)
+	ClusterIPPrivate  = ClusterIPServiceFlag(1 << iota)
+)
+
 // NewClusterIPServiceList creates a list of ClusterIP services
-func NewClusterIPServiceList(role *model.Role, headless, private bool, settings ExportSettings) (helm.Node, error) {
+func NewClusterIPServiceList(role *model.Role, flags ClusterIPServiceFlag, settings ExportSettings) (helm.Node, error) {
 	var items []helm.Node
 
-	if headless {
+	if flags&ClusterIPHeadless != 0 {
 		// Create headless, private service
 		svc, err := NewClusterIPService(role, true, false, settings)
 		if err != nil {
@@ -22,7 +31,7 @@ func NewClusterIPServiceList(role *model.Role, headless, private bool, settings 
 		}
 	}
 
-	if private {
+	if flags&ClusterIPPrivate != 0 {
 		// Create private service
 		svc, err := NewClusterIPService(role, false, false, settings)
 		if err != nil {

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -3,8 +3,10 @@ package kube
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/SUSE/fissile/helm"
 	"github.com/SUSE/fissile/model"
 	"github.com/SUSE/fissile/testhelpers"
 
@@ -48,7 +50,7 @@ func TestServiceKube(t *testing.T) {
 	if !assert.NotNil(portDef) {
 		return
 	}
-	service, err := NewClusterIPService(role, false, false, ExportSettings{})
+	service, err := newService(role, newServiceTypePrivate, ExportSettings{})
 	require.NoError(t, err)
 	require.NotNil(t, service)
 
@@ -84,7 +86,7 @@ func TestServiceHelm(t *testing.T) {
 
 	portDef := role.Run.ExposedPorts[0]
 	require.NotNil(t, portDef)
-	service, err := NewClusterIPService(role, false, false, ExportSettings{
+	service, err := newService(role, newServiceTypePrivate, ExportSettings{
 		CreateHelmChart: true,
 	})
 	require.NoError(t, err)
@@ -160,7 +162,7 @@ func TestHeadlessServiceKube(t *testing.T) {
 	portDef := role.Run.ExposedPorts[0]
 	require.NotNil(t, portDef)
 
-	service, err := NewClusterIPService(role, true, false, ExportSettings{})
+	service, err := newService(role, newServiceTypeHeadless, ExportSettings{})
 	require.NoError(t, err)
 	require.NotNil(t, service)
 
@@ -200,7 +202,7 @@ func TestHeadlessServiceHelm(t *testing.T) {
 	portDef := role.Run.ExposedPorts[0]
 	require.NotNil(t, portDef)
 
-	service, err := NewClusterIPService(role, true, false, ExportSettings{
+	service, err := newService(role, newServiceTypeHeadless, ExportSettings{
 		CreateHelmChart: true,
 	})
 	require.NoError(t, err)
@@ -277,7 +279,7 @@ func TestPublicServiceKube(t *testing.T) {
 	portDef := role.Run.ExposedPorts[0]
 	require.NotNil(t, portDef)
 
-	service, err := NewClusterIPService(role, false, true, ExportSettings{})
+	service, err := newService(role, newServiceTypePublic, ExportSettings{})
 	require.NoError(t, err)
 	require.NotNil(t, service)
 
@@ -287,7 +289,7 @@ func TestPublicServiceKube(t *testing.T) {
 		metadata:
 			name: myrole-public
 		spec:
-			externalIPs: '[ 192.168.77.77 ]'
+			externalIPs: [ 192.168.77.77 ]
 			ports:
 			-
 				name: https
@@ -311,7 +313,7 @@ func TestPublicServiceHelm(t *testing.T) {
 	portDef := role.Run.ExposedPorts[0]
 	require.NotNil(t, portDef)
 
-	service, err := NewClusterIPService(role, false, true, ExportSettings{
+	service, err := newService(role, newServiceTypePublic, ExportSettings{
 		CreateHelmChart: true,
 	})
 	require.NoError(t, err)
@@ -370,4 +372,185 @@ func TestPublicServiceHelm(t *testing.T) {
 				type:	LoadBalancer
 		`, actual)
 	})
+}
+
+func TestActivePassiveService(t *testing.T) {
+	t.Parallel()
+	manifest, role := serviceTestLoadRole(assert.New(t), "exposed-ports.yml")
+	if manifest == nil || role == nil {
+		return
+	}
+
+	require.NotNil(t, role.Run, "Role has no run information")
+	require.NotEmpty(t, role.Run.ExposedPorts, "Role has no exposed ports")
+	role.Tags = []model.RoleTag{model.RoleTagActivePassive}
+
+	const (
+		withKube             = "kube"
+		withHelm             = "helm"
+		withHelmLoadBalancer = "helm with load balancer"
+	)
+	const (
+		withClustering    = "clustering"
+		withOutClustering = "not clustering"
+	)
+
+	for _, variant := range []string{withKube, withHelm, withHelmLoadBalancer} {
+		func(variant string) {
+			roundTrip := func(node helm.Node) (interface{}, error) {
+				switch variant {
+				case withKube:
+					return testhelpers.RoundtripKube(node)
+				case withHelm:
+					config := map[string]interface{}{
+						"Values.kube.external_ips": []string{"192.0.2.42"},
+					}
+					return testhelpers.RoundtripNode(node, config)
+				case withHelmLoadBalancer:
+					config := map[string]interface{}{
+						"Values.kube.external_ips":     []string{"192.0.2.42"},
+						"Values.services.loadbalanced": "true",
+					}
+					return testhelpers.RoundtripNode(node, config)
+				}
+				panic("Unexpected variant " + variant)
+			}
+
+			t.Run(variant, func(t *testing.T) {
+				t.Parallel()
+				for _, clustering := range []string{withClustering, withOutClustering} {
+					func(clustering string) {
+						t.Run(clustering, func(t *testing.T) {
+							t.Parallel()
+
+							exportSettings := ExportSettings{CreateHelmChart: variant != withKube}
+							services, err := NewServiceList(role, clustering == withClustering, exportSettings)
+							require.NoError(t, err)
+							require.NotNil(t, services, "No services created")
+
+							var headlessService, privateService, publicService helm.Node
+							for _, service := range services.Get("items").Values() {
+								serviceName := service.Get("metadata", "name").String()
+								switch serviceName {
+								case "myrole-set":
+									headlessService = service
+								case "myrole":
+									privateService = service
+								case "myrole-public":
+									publicService = service
+								default:
+									assert.Fail(t, "Unexpected service "+serviceName)
+								}
+							}
+
+							if clustering == withClustering {
+								if assert.NotNil(t, headlessService, "headless service not found") {
+									actual, err := roundTrip(headlessService)
+									if assert.NoError(t, err) {
+										expected := `---
+											apiVersion: v1
+											kind: Service
+											metadata:
+												name: myrole-set
+											spec:
+												clusterIP: None
+												ports:
+												-
+													name: http
+													port: 80
+													protocol: TCP
+													targetPort: 0
+												-
+													name: https
+													port: 443
+													protocol: TCP
+													targetPort: 0
+												selector:
+													skiff-role-name: myrole
+													skiff-role-active: "true"
+												type: ClusterIP
+										`
+										switch variant {
+										case withHelmLoadBalancer:
+											expected = strings.Replace(expected, "type: ClusterIP", "type: LoadBalancer", 1)
+											expected = strings.Replace(expected, "clusterIP: None", "", 1)
+										}
+										testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
+									}
+								}
+							} else {
+								assert.Nil(t, headlessService, "Headless service should not be created when not clustering")
+							}
+
+							if assert.NotNil(t, privateService, "private service not found") {
+								actual, err := roundTrip(privateService)
+								if assert.NoError(t, err) {
+
+									expected := `---
+										apiVersion: v1
+										kind: Service
+										metadata:
+											name: myrole
+										spec:
+											ports:
+											-
+												name: http
+												port: 80
+												protocol: TCP
+												targetPort: http
+											-
+												name: https
+												port: 443
+												protocol: TCP
+												targetPort: https
+											selector:
+												skiff-role-name: myrole
+												skiff-role-active: "true"
+											type: ClusterIP
+									`
+									switch variant {
+									case withHelmLoadBalancer:
+										expected = strings.Replace(expected, "type: ClusterIP", "type: LoadBalancer", 1)
+									}
+									testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
+								}
+							}
+
+							if assert.NotNil(t, publicService, "public service not found") {
+								actual, err := roundTrip(publicService)
+								if assert.NoError(t, err) {
+									expected := `---
+										apiVersion: v1
+										kind: Service
+										metadata:
+											name: myrole-public
+										spec:
+											externalIPs: [ 192.0.2.42 ]
+											ports:
+											-
+												name: https
+												port: 443
+												protocol: TCP
+												targetPort: https
+											selector:
+												skiff-role-name: myrole
+												skiff-role-active: "true"
+											type: ClusterIP
+									`
+									switch variant {
+									case withHelmLoadBalancer:
+										expected = strings.Replace(expected, "type: ClusterIP", "type: LoadBalancer", 1)
+									case withKube:
+										expected = strings.Replace(expected, "192.0.2.42", "192.168.77.77", 1)
+									}
+									testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
+								}
+							}
+
+						})
+					}(clustering)
+				}
+			})
+		}(variant)
+	}
 }

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -397,27 +397,27 @@ func TestActivePassiveService(t *testing.T) {
 
 	for _, variant := range []string{withKube, withHelm, withHelmLoadBalancer} {
 		func(variant string) {
-			roundTrip := func(node helm.Node) (interface{}, error) {
-				switch variant {
-				case withKube:
-					return testhelpers.RoundtripKube(node)
-				case withHelm:
-					config := map[string]interface{}{
-						"Values.kube.external_ips": []string{"192.0.2.42"},
-					}
-					return testhelpers.RoundtripNode(node, config)
-				case withHelmLoadBalancer:
-					config := map[string]interface{}{
-						"Values.kube.external_ips":     []string{"192.0.2.42"},
-						"Values.services.loadbalanced": "true",
-					}
-					return testhelpers.RoundtripNode(node, config)
-				}
-				panic("Unexpected variant " + variant)
-			}
-
 			t.Run(variant, func(t *testing.T) {
 				t.Parallel()
+				roundTrip := func(node helm.Node) (interface{}, error) {
+					switch variant {
+					case withKube:
+						return testhelpers.RoundtripKube(node)
+					case withHelm:
+						config := map[string]interface{}{
+							"Values.kube.external_ips": []string{"192.0.2.42"},
+						}
+						return testhelpers.RoundtripNode(node, config)
+					case withHelmLoadBalancer:
+						config := map[string]interface{}{
+							"Values.kube.external_ips":     []string{"192.0.2.42"},
+							"Values.services.loadbalanced": "true",
+						}
+						return testhelpers.RoundtripNode(node, config)
+					}
+					panic("Unexpected variant " + variant)
+				}
+
 				for _, clustering := range []string{withClustering, withOutClustering} {
 					func(clustering string) {
 						t.Run(clustering, func(t *testing.T) {

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -40,6 +40,11 @@ func NewStatefulSet(role *model.Role, settings ExportSettings, grapher util.Mode
 	if len(claims) > 0 {
 		spec.Add("volumeClaimTemplates", helm.NewNode(claims))
 	}
+	podManagementPolicy := "Parallel"
+	if role.HasTag(model.RoleTagSequentialStartup) {
+		podManagementPolicy = "OrderedReady"
+	}
+	spec.Add("podManagementPolicy", podManagementPolicy)
 
 	statefulSet := newKubeConfig("apps/v1beta1", "StatefulSet", role.Name, helm.Comment(role.GetLongDescription()))
 	statefulSet.Add("spec", spec)

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -21,7 +21,11 @@ func NewStatefulSet(role *model.Role, settings ExportSettings, grapher util.Mode
 		return nil, nil, err
 	}
 
-	svcList, err := NewClusterIPServiceList(role, true, !role.HasTag(model.RoleTagClustered), settings)
+	flags := ClusterIPHeadless
+	if !role.HasTag(model.RoleTagHeadless) {
+		flags |= ClusterIPPrivate
+	}
+	svcList, err := NewClusterIPServiceList(role, flags, settings)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -21,7 +21,7 @@ func NewStatefulSet(role *model.Role, settings ExportSettings, grapher util.Mode
 		return nil, nil, err
 	}
 
-	svcList, err := NewClusterIPServiceList(role, true, !role.HasTag("clustered"), settings)
+	svcList, err := NewClusterIPServiceList(role, true, !role.HasTag(model.RoleTagClustered), settings)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -21,11 +21,7 @@ func NewStatefulSet(role *model.Role, settings ExportSettings, grapher util.Mode
 		return nil, nil, err
 	}
 
-	flags := ClusterIPHeadless
-	if !role.HasTag(model.RoleTagHeadless) {
-		flags |= ClusterIPPrivate
-	}
-	svcList, err := NewClusterIPServiceList(role, flags, settings)
+	svcList, err := NewServiceList(role, true, settings)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -231,6 +231,11 @@ func TestStatefulSetServices(t *testing.T) {
 								type: ClusterIP
 							`, actual)
 						}
+						if variant == "headless" {
+							assert.Nil(t, publicService, "headless roles should not have public services")
+							assert.Nil(t, internalService, "headless roles should not have internal services")
+							return
+						}
 						if assert.NotNil(t, publicService, "Public service not found") {
 							var actual interface{}
 							var err error
@@ -249,7 +254,7 @@ func TestStatefulSetServices(t *testing.T) {
 							metadata:
 								name: myrole-public
 							spec:
-								externalIPs: '[ 192.168.77.77 ]'
+								externalIPs: [ 192.168.77.77 ]
 								ports:
 								-
 									name: https
@@ -260,10 +265,6 @@ func TestStatefulSetServices(t *testing.T) {
 									skiff-role-name: myrole
 								type: ClusterIP
 							`, actual)
-						}
-						if variant == "headless" {
-							assert.Nil(t, internalService, "headless roles should not have internal services")
-							return
 						}
 						if assert.NotNil(t, internalService, "Internal service not found") {
 							var actual interface{}

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -231,11 +231,6 @@ func TestStatefulSetServices(t *testing.T) {
 								type: ClusterIP
 							`, actual)
 						}
-						if variant == "headless" {
-							assert.Nil(t, publicService, "headless roles should not have public services")
-							assert.Nil(t, internalService, "headless roles should not have internal services")
-							return
-						}
 						if assert.NotNil(t, publicService, "Public service not found") {
 							var actual interface{}
 							var err error
@@ -266,7 +261,9 @@ func TestStatefulSetServices(t *testing.T) {
 								type: ClusterIP
 							`, actual)
 						}
-						if assert.NotNil(t, internalService, "Internal service not found") {
+						if variant == "headless" {
+							assert.Nil(t, internalService, "headless roles should not have internal services")
+						} else if assert.NotNil(t, internalService, "Internal service not found") {
 							var actual interface{}
 							var err error
 							switch style {

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -536,6 +536,7 @@ func TestStatefulSetVolumesHelm(t *testing.T) {
 
 	config := map[string]interface{}{
 		"Values.env.ALL_VAR":                                "",
+		"Values.kube.hostpath_available":                    true,
 		"Values.kube.registry.hostname":                     "",
 		"Values.kube.storage_class.persistent":              "persistent",
 		"Values.kube.storage_class.shared":                  "shared",

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -346,8 +346,9 @@ func TestStatefulSetStartupPolicy(t *testing.T) {
 					}, nil)
 					require.NoError(t, err)
 					actual, err := testhelpers.RoundtripNode(statefulset, map[string]interface{}{
-						"Values.sizing.myrole.count":        "1",
-						"Values.sizing.myrole.capabilities": []string{},
+						"Values.sizing.myrole.count":                        "1",
+						"Values.sizing.myrole.capabilities":                 []string{},
+						"Values.sizing.myrole.disk_sizes.persistent_volume": 1,
 					})
 					require.NoError(t, err)
 					expected := `---

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -38,26 +38,20 @@ func statefulSetTestLoadManifest(assert *assert.Assertions, manifestName string)
 }
 
 func TestStatefulSetPorts(t *testing.T) {
-	assert := assert.New(t)
-
-	manifest, role := statefulSetTestLoadManifest(assert, "exposed-ports.yml")
+	manifest, role := statefulSetTestLoadManifest(assert.New(t), "exposed-ports.yml")
 	if manifest == nil || role == nil {
 		return
 	}
 
 	portDef := role.Run.ExposedPorts[0]
-	if !assert.NotNil(portDef) {
-		return
-	}
+	require.NotNil(t, portDef)
 
 	statefulset, deps, err := NewStatefulSet(role, ExportSettings{}, nil)
-	if !assert.NoError(err) {
-		return
-	}
+	require.NoError(t, err)
 
 	var endpointService, headlessService, privateService helm.Node
 	items := deps.Get("items").Values()
-	if assert.Len(items, 3, "Should have three services per stateful role") {
+	if assert.Len(t, items, 3, "Should have three services per stateful role") {
 		for _, item := range items {
 			clusterIP := item.Get("spec", "clusterIP")
 			if clusterIP != nil && clusterIP.String() == "None" {
@@ -69,23 +63,21 @@ func TestStatefulSetPorts(t *testing.T) {
 			}
 		}
 	}
-	if assert.NotNil(endpointService, "endpoint service not found") {
-		assert.Equal(role.Name+"-public", endpointService.Get("metadata", "name").String(), "unexpected endpoint service name")
+	if assert.NotNil(t, endpointService, "endpoint service not found") {
+		assert.Equal(t, role.Name+"-public", endpointService.Get("metadata", "name").String(), "unexpected endpoint service name")
 	}
-	if assert.NotNil(headlessService, "headless service not found") {
-		assert.Equal(role.Name+"-set", headlessService.Get("metadata", "name").String(), "unexpected headless service name")
+	if assert.NotNil(t, headlessService, "headless service not found") {
+		assert.Equal(t, role.Name+"-set", headlessService.Get("metadata", "name").String(), "unexpected headless service name")
 	}
-	if assert.NotNil(privateService, "private service not found") {
-		assert.Equal(role.Name, privateService.Get("metadata", "name").String(), "unexpected private service name")
+	if assert.NotNil(t, privateService, "private service not found") {
+		assert.Equal(t, role.Name, privateService.Get("metadata", "name").String(), "unexpected private service name")
 	}
 
 	items = append(items, statefulset)
 	objects := helm.NewMapping("items", helm.NewNode(items))
 
 	actual, err := testhelpers.RoundtripKube(objects)
-	if !assert.NoError(err) {
-		return
-	}
+	require.NoError(t, err)
 
 	expected := `---
 		items:
@@ -163,7 +155,151 @@ func TestStatefulSetPorts(t *testing.T) {
 								name: https
 								containerPort: 443
 	`
-	testhelpers.IsYAMLSubsetString(assert, expected, actual)
+	testhelpers.IsYAMLSubsetString(assert.New(t), expected, actual)
+}
+
+// TestStatefulSetServices checks that the services associated with a service
+// are created correctly.
+func TestStatefulSetServices(t *testing.T) {
+	for _, variant := range []string{"headless", "headed"} {
+		t.Run(variant, func(t *testing.T) {
+			manifestName := "service-" + variant + ".yml"
+			manifest, role := statefulSetTestLoadManifest(assert.New(t), manifestName)
+			require.NotNil(t, manifest)
+			require.NotNil(t, role)
+			require.NotEmpty(t, role.Run.ExposedPorts, "No exposed ports loaded")
+
+			statefulset, deps, err := NewStatefulSet(role, ExportSettings{}, nil)
+			require.NoError(t, err)
+			assert.NotNil(t, statefulset)
+			assert.NotNil(t, deps)
+			items := deps.Get("items").Values()
+
+			var headlessService, internalService, publicService helm.Node
+			for _, item := range items {
+				switch item.Get("metadata").Get("name").String() {
+				case "myrole-set":
+					assert.Nil(t, headlessService, "Multiple headless services found")
+					headlessService = item
+				case "myrole":
+					assert.Nil(t, internalService, "Multiple internal services found")
+					internalService = item
+				case "myrole-public":
+					assert.Nil(t, publicService, "Multiple public services found")
+					publicService = item
+				default:
+					assert.Failf(t, "Found unexpected service: \n%s", item.String())
+				}
+			}
+			for _, style := range []string{"kube", "helm"} {
+				t.Run(style, func(t *testing.T) {
+					if assert.NotNil(t, headlessService, "Headless service not found") {
+						var actual interface{}
+						var err error
+						switch style {
+						case "helm":
+							actual, err = testhelpers.RoundtripNode(headlessService, nil)
+						case "kube":
+							actual, err = testhelpers.RoundtripKube(headlessService)
+						default:
+							panic("Unexpected style " + style)
+						}
+						require.NoError(t, err)
+						testhelpers.IsYAMLEqualString(assert.New(t), `---
+							apiVersion: v1
+							kind: Service
+							metadata:
+								name: myrole-set
+							spec:
+								clusterIP: None
+								ports:
+								-
+									name: http
+									port: 80
+									protocol: TCP
+									targetPort: 0
+								-
+									name: https
+									port: 443
+									protocol: TCP
+									targetPort: 0
+								selector:
+									skiff-role-name: myrole
+								type: ClusterIP
+							`, actual)
+					}
+					if assert.NotNil(t, publicService, "Public service not found") {
+						var actual interface{}
+						var err error
+						switch style {
+						case "helm":
+							actual, err = testhelpers.RoundtripNode(publicService, nil)
+						case "kube":
+							actual, err = testhelpers.RoundtripKube(publicService)
+						default:
+							panic("Unexpected style " + style)
+						}
+						require.NoError(t, err)
+						testhelpers.IsYAMLEqualString(assert.New(t), `---
+							apiVersion: v1
+							kind: Service
+							metadata:
+								name: myrole-public
+							spec:
+								externalIPs: '[ 192.168.77.77 ]'
+								ports:
+								-
+									name: https
+									port: 443
+									protocol: TCP
+									targetPort: https
+								selector:
+									skiff-role-name: myrole
+								type: ClusterIP
+							`, actual)
+					}
+					if variant == "headless" {
+						assert.Nil(t, internalService, "headless roles should not have internal services")
+						return
+					}
+					if assert.NotNil(t, internalService, "Internal service not found") {
+						var actual interface{}
+						var err error
+						switch style {
+						case "helm":
+							actual, err = testhelpers.RoundtripNode(internalService, nil)
+						case "kube":
+							actual, err = testhelpers.RoundtripKube(internalService)
+						default:
+							panic("Unexpected style " + style)
+						}
+						require.NoError(t, err)
+						testhelpers.IsYAMLEqualString(assert.New(t), `---
+							apiVersion: v1
+							kind: Service
+							metadata:
+								name: myrole
+							spec:
+								ports:
+								-
+									name: http
+									port: 80
+									protocol: TCP
+									targetPort: http
+								-
+									name: https
+									port: 443
+									protocol: TCP
+									targetPort: https
+								selector:
+									skiff-role-name: myrole
+								type: ClusterIP
+							`, actual)
+					}
+				})
+			}
+		})
+	}
 }
 
 // TestStatefulSetStart checks that roles with the `sequential-startup` tag will

--- a/kube/values.go
+++ b/kube/values.go
@@ -72,7 +72,7 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 
 	sizing := helm.NewMapping()
 	for _, role := range settings.RoleManifest.Roles {
-		if role.IsDevRole() || role.Run.FlightStage == model.FlightStageManual {
+		if role.Run.FlightStage == model.FlightStageManual {
 			continue
 		}
 

--- a/kube/values.go
+++ b/kube/values.go
@@ -10,6 +10,7 @@ import (
 
 // MakeValues returns a Mapping with all default values for the Helm chart
 func MakeValues(settings ExportSettings) (helm.Node, error) {
+	values := helm.MakeBasicValues()
 	env := helm.NewMapping()
 	secrets := helm.NewMapping()
 	generated := helm.NewMapping()
@@ -56,19 +57,8 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	}
 	secrets.Sort()
 	secrets.Merge(generated.Sort())
-
-	memConfig := helm.NewMapping()
-	memConfig.Add("requests", false, helm.Comment("Flag to activate memory requests"))
-	memConfig.Add("limits", false, helm.Comment("Flag to activate memory limits"))
-
-	cpuConfig := helm.NewMapping()
-	cpuConfig.Add("requests", false, helm.Comment("Flag to activate cpu requests"))
-	cpuConfig.Add("limits", false, helm.Comment("Flag to activate cpu limits"))
-
-	config := helm.NewMapping()
-	config.Add("HA", false, helm.Comment("Flag to activate high-availability mode"))
-	config.Add("memory", memConfig, helm.Comment("Global memory configuration"))
-	config.Add("cpu", cpuConfig, helm.Comment("Global CPU configuration"))
+	values.Add("secrets", secrets.Sort())
+	values.Add("env", env.Sort())
 
 	sizing := helm.NewMapping()
 	for _, role := range settings.RoleManifest.Roles {
@@ -169,6 +159,7 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 
 		sizing.Add(makeVarName(role.Name), entry.Sort(), helm.Comment(role.GetLongDescription()))
 	}
+	values.Add("sizing", sizing.Sort())
 
 	registry := settings.Registry
 	if registry == "" {
@@ -177,32 +168,15 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 		// if registry is blank.
 		registry = "docker.io"
 	}
-	registryInfo := helm.NewMapping()
-	registryInfo.Add("hostname", registry)
-	registryInfo.Add("username", settings.Username)
-	registryInfo.Add("password", settings.Password)
-
-	kube := helm.NewMapping()
-	kube.Add("external_ips", helm.NewList())
-	kube.Add("secrets_generation_counter", 1, helm.Comment("Increment this counter to rotate all generated secrets"))
-	kube.Add("storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"))
-	kube.Add("hostpath_available", false, helm.Comment("Whether HostPath volume mounts are available"))
-	kube.Add("registry", registryInfo)
-	kube.Add("organization", settings.Organization)
-
-	if settings.AuthType == "" {
-		kube.Add("auth", nil)
-	} else {
-		kube.Add("auth", settings.AuthType)
+	// Override registry settings
+	values.Get("kube").(*helm.Mapping).Add("registry", helm.NewMapping(
+		"hostname", registry,
+		"username", settings.Username,
+		"password", settings.Password))
+	values.Get("kube").(*helm.Mapping).Add("organization", settings.Organization)
+	if settings.AuthType != "" {
+		values.Get("kube").(*helm.Mapping).Add("auth", settings.AuthType)
 	}
-
-	values := helm.NewMapping()
-	values.Add("config", config.Sort())
-	values.Add("env", env.Sort())
-	values.Add("sizing", sizing.Sort())
-	values.Add("secrets", secrets)
-	values.Add("services", helm.NewMapping("loadbalanced", false))
-	values.Add("kube", kube)
 
 	return values, nil
 }

--- a/model/roles.go
+++ b/model/roles.go
@@ -1232,12 +1232,6 @@ func validateRoleRun(role *Role, roleManifest *RoleManifest, declared CVMap) val
 
 	for _, exposedPort := range role.Run.ExposedPorts {
 		allErrs = append(allErrs, ValidateExposedPorts(role.Name, exposedPort)...)
-		if role.HasTag(RoleTagHeadless) && exposedPort.Public {
-			allErrs = append(allErrs, validation.Invalid(
-				fmt.Sprintf("roles[%s].run.exposed-ports[%s].public", role.Name, exposedPort.Name),
-				true,
-				"Public ports on headless roles cannot be used"))
-		}
 	}
 
 	if role.Run.ServiceAccount != "" {

--- a/model/roles.go
+++ b/model/roles.go
@@ -1724,18 +1724,6 @@ func (r *Role) IsPrivileged() bool {
 	return false
 }
 
-// IsDevRole tests if the role is tagged for development, or not. It
-// returns true for development-roles, and false otherwise.
-func (r *Role) IsDevRole() bool {
-	for _, tag := range r.Tags {
-		switch tag {
-		case "dev-only":
-			return true
-		}
-	}
-	return false
-}
-
 // IsColocatedContainerRole tests if the role is of type ColocatedContainer, or
 // not. It returns true if this role is of that type, or false otherwise.
 func (r *Role) IsColocatedContainerRole() bool {

--- a/model/roles.go
+++ b/model/roles.go
@@ -76,7 +76,6 @@ type RoleTag string
 
 // The list of acceptable tags
 const (
-	RoleTagClustered         = RoleTag("clustered")
 	RoleTagIndexed           = RoleTag("indexed")
 	RoleTagStopOnFailure     = RoleTag("stop-on-failure")
 	RoleTagSequentialStartup = RoleTag("sequential-startup")
@@ -403,7 +402,6 @@ func LoadRoleManifest(manifestFilePath string, releases []*Release, grapher util
 
 		for tagNum, tag := range role.Tags {
 			switch tag {
-			case RoleTagClustered:
 			case RoleTagIndexed:
 			case RoleTagStopOnFailure:
 			case RoleTagSequentialStartup:

--- a/model/roles.go
+++ b/model/roles.go
@@ -1700,6 +1700,13 @@ func validateRoleTags(role *Role) validation.ErrorList {
 					fmt.Sprintf("roles[%s].run.active-passive-probe", role.Name),
 					"active-passive roles must specify the correct probe"))
 			}
+			if role.HasTag(RoleTagHeadless) {
+				allErrs = append(allErrs, validation.Invalid(
+					fmt.Sprintf("roles[%s].tags[%d]", role.Name, tagNum),
+					tag,
+					"headless roles may not be active-passive"))
+			}
+
 		default:
 			allErrs = append(allErrs, validation.Invalid(
 				fmt.Sprintf("roles[%s].tags[%d]", role.Name, tagNum),

--- a/model/roles.go
+++ b/model/roles.go
@@ -1230,8 +1230,14 @@ func validateRoleRun(role *Role, roleManifest *RoleManifest, declared CVMap) val
 	allErrs = append(allErrs, validateRoleMemory(role)...)
 	allErrs = append(allErrs, validateRoleCPU(role)...)
 
-	for i := range role.Run.ExposedPorts {
-		allErrs = append(allErrs, ValidateExposedPorts(role.Name, role.Run.ExposedPorts[i])...)
+	for _, exposedPort := range role.Run.ExposedPorts {
+		allErrs = append(allErrs, ValidateExposedPorts(role.Name, exposedPort)...)
+		if role.HasTag(RoleTagHeadless) && exposedPort.Public {
+			allErrs = append(allErrs, validation.Invalid(
+				fmt.Sprintf("roles[%s].run.exposed-ports[%s].public", role.Name, exposedPort.Name),
+				true,
+				"Public ports on headless roles cannot be used"))
+		}
 	}
 
 	if role.Run.ServiceAccount != "" {

--- a/model/roles.go
+++ b/model/roles.go
@@ -80,6 +80,7 @@ const (
 	RoleTagIndexed           = RoleTag("indexed")
 	RoleTagStopOnFailure     = RoleTag("stop-on-failure")
 	RoleTagSequentialStartup = RoleTag("sequential-startup")
+	RoleTagHeadless          = RoleTag("headless")
 )
 
 // Role represents a collection of jobs that are colocated on a container
@@ -405,6 +406,8 @@ func LoadRoleManifest(manifestFilePath string, releases []*Release, grapher util
 			case RoleTagClustered:
 			case RoleTagIndexed:
 			case RoleTagStopOnFailure:
+			case RoleTagSequentialStartup:
+			case RoleTagHeadless:
 				// Ignore the known tags
 			default:
 				allErrs = append(allErrs, validation.Invalid(

--- a/model/roles.go
+++ b/model/roles.go
@@ -76,9 +76,10 @@ type RoleTag string
 
 // The list of acceptable tags
 const (
-	RoleTagClustered     = RoleTag("clustered")
-	RoleTagIndexed       = RoleTag("indexed")
-	RoleTagStopOnFailure = RoleTag("stop-on-failure")
+	RoleTagClustered         = RoleTag("clustered")
+	RoleTagIndexed           = RoleTag("indexed")
+	RoleTagStopOnFailure     = RoleTag("stop-on-failure")
+	RoleTagSequentialStartup = RoleTag("sequential-startup")
 )
 
 // Role represents a collection of jobs that are colocated on a container

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -989,7 +989,7 @@ func TestLoadRoleManifestColocatedContainersValidationInvalidTags(t *testing.T) 
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/model/colocated-containers-with-clustered-tag.yml")
 	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{torRelease, ntpRelease}, nil)
 	assert.Nil(roleManifest)
-	assert.EqualError(err, "role[to-be-colocated]: Invalid value: \"clustered\": tags clustered, or indexed are not supported for colocated-containers")
+	assert.EqualError(err, `roles[to-be-colocated].tags[0]: Invalid value: "headless": headless tag is only supported in [bosh, docker] roles, not colocated-container`)
 }
 
 func TestLoadRoleManifestColocatedContainersValidationOfSharedVolumes(t *testing.T) {

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -187,6 +187,10 @@ func TestRoleManifestTagList(t *testing.T) {
 				roleManifest.Configuration = &Configuration{Templates: map[string]string{}}
 				require.NotEmpty(t, roleManifest.Roles, "No roles loaded")
 				roleManifest.Roles[0].Tags = []RoleTag{RoleTag(tag)}
+				if RoleTag(tag) == RoleTagActivePassive {
+					// An active/passive probe is required when tagged as active/passive
+					roleManifest.Roles[0].Run.ActivePassiveProbe = "hello"
+				}
 				err = roleManifest.resolveRoleManifest([]*Release{release}, nil)
 				if acceptable {
 					assert.NoError(t, err)

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -540,6 +540,11 @@ func TestLoadRoleManifestRunGeneral(t *testing.T) {
 			},
 		},
 		{
+			"bosh-run-headless-public-port.yml", []string{
+				`roles[myrole].run.exposed-ports[http].public: Invalid value: true: Public ports on headless roles cannot be used`,
+			},
+		},
+		{
 			"bosh-run-bad-parse.yml", []string{
 				`roles[myrole].run.exposed-ports[https].internal: Invalid value: "qq": invalid syntax`,
 				`roles[myrole].run.exposed-ports[https].external: Invalid value: "aa": invalid syntax`,

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -742,12 +742,26 @@ func TestLoadRoleManifestHealthChecks(t *testing.T) {
 
 		roleManifest.Roles[0].Type = RoleTypeBoshTask
 		roleManifest.Roles[0].Tags = []RoleTag{RoleTagActivePassive}
-		roleManifest.Roles[0].Run = &RoleRun{
-			ActivePassiveProbe: "/bin/false",
-		}
+		roleManifest.Roles[0].Run = &RoleRun{ActivePassiveProbe: "/bin/false"}
 		err = roleManifest.resolveRoleManifest([]*Release{release}, nil)
 		assert.EqualError(t, err,
 			`roles[myrole].tags[0]: Invalid value: "active-passive": active-passive roles must be BOSH roles`)
+	})
+
+	t.Run("headless active/passive role", func(t *testing.T) {
+		t.Parallel()
+		roleManifest := &RoleManifest{manifestFilePath: roleManifestPath}
+		err := yaml.Unmarshal(manifestContents, roleManifest)
+		require.NoError(t, err, "Error unmarshalling role manifest")
+		roleManifest.Configuration = &Configuration{Templates: map[string]string{}}
+		require.NotEmpty(t, roleManifest.Roles, "No roles loaded")
+
+		roleManifest.Roles[0].Type = RoleTypeBosh
+		roleManifest.Roles[0].Tags = []RoleTag{RoleTagHeadless, RoleTagActivePassive}
+		roleManifest.Roles[0].Run = &RoleRun{ActivePassiveProbe: "/bin/false"}
+		err = roleManifest.resolveRoleManifest([]*Release{release}, nil)
+		assert.EqualError(t, err,
+			`roles[myrole].tags[1]: Invalid value: "active-passive": headless roles may not be active-passive`)
 	})
 }
 

--- a/scripts/dockerfiles/Dockerfile-role
+++ b/scripts/dockerfiles/Dockerfile-role
@@ -8,5 +8,4 @@ LABEL "role"="{{ .role.Name }}"
 
 ADD root /
 
-RUN chmod +x /opt/fissile/run.sh /opt/fissile/pre-stop.sh
 ENTRYPOINT ["/usr/bin/dumb-init", "/opt/fissile/run.sh"]

--- a/scripts/dockerfiles/readiness-probe.sh
+++ b/scripts/dockerfiles/readiness-probe.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# This is the default readiness probe, which will look at all monit monitored
+# processes and check that they are ready.
+
+# It may optionally be launched with other scripts as arguments; for each
+# argument, it will run it as a command, and report not ready if any one returns
+# a non-zero exit status.
+
+# If the enviroment variable `FISSILE_ACTIVE_CHECK` is set, that is assumed to
+# be a command which, when run, will report if this pod should be placed in the
+# set of pods accepting traffic.  An exit status of zero in that case is assumed
+# to mean the pod is ready for traffic.
+
+###
+
+set -o errexit -o nounset
+
+# Check that monit thinks everything is ready
+/var/vcap/bosh/bin/monit summary | gawk '
+    BEGIN                                 { status = 0 }
+    $1 == "Process" && $3 != "running"    { print ; status = 1 }
+    $1 == "File"    && $3 != "accessible" { print ; status = 1 }
+    END                                   { exit status }
+    '
+
+# Check that any additional readiness checks are ready
+for command in "${@}" ; do
+    /usr/bin/env bash -c "${command}"
+done
+
+# If this is an active/passive role, do that check
+if test -n "${FISSILE_ACTIVE_PASSIVE_PROBE:-}" ; then
+
+    update_readiness() {
+        local svcacct=/var/run/secrets/kubernetes.io/serviceaccount
+        curl --silent \
+            --cacert "${svcacct}/ca.crt" \
+            -H "Authorization: bearer $(cat "${svcacct}/token")" \
+            -H 'Content-Type: application/merge-patch+json' \
+            -X 'PATCH' \
+            "https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}/api/v1/namespaces/$(cat "${svcacct}/namespace")/pods/${HOSTNAME}" \
+            --data '{
+                "metadata": {
+                    "labels": {
+                        "skiff-role-active": "'"${1}"'"
+                    }
+                }
+            }'
+        return $?
+    }
+
+    if eval ${FISSILE_ACTIVE_PASSIVE_PROBE} ; then
+        update_readiness true
+    else
+        update_readiness false
+    fi
+fi

--- a/test-assets/role-manifests/app/two-roles.yml
+++ b/test-assets/role-manifests/app/two-roles.yml
@@ -9,7 +9,6 @@ roles:
       max: 2
 - name: myrole-clustered
   jobs: []
-  tags: [ clustered ]
   run:
     scaling:
       min: 1

--- a/test-assets/role-manifests/kube/service-headed.yml
+++ b/test-assets/role-manifests/kube/service-headed.yml
@@ -1,0 +1,20 @@
+# This is a role with exposed ports, and without the headless tag
+---
+roles:
+- name: myrole
+  jobs: []
+  run:
+    scaling:
+      min: 1
+      max: 2
+    exposed-ports:
+      - name: http
+        protocol: TCP
+        external: 80
+        internal: 8080
+        public: false
+      - name: https
+        protocol: TCP
+        external: 443
+        internal: 443
+        public: true

--- a/test-assets/role-manifests/kube/service-headless.yml
+++ b/test-assets/role-manifests/kube/service-headless.yml
@@ -1,0 +1,22 @@
+# This is a role with exposed ports, and _with_ the headless tag
+---
+roles:
+- name: myrole
+  jobs: []
+  tags:
+  - headless
+  run:
+    scaling:
+      min: 1
+      max: 2
+    exposed-ports:
+      - name: http
+        protocol: TCP
+        external: 80
+        internal: 8080
+        public: false
+      - name: https
+        protocol: TCP
+        external: 443
+        internal: 443
+        public: true

--- a/test-assets/role-manifests/kube/service-headless.yml
+++ b/test-assets/role-manifests/kube/service-headless.yml
@@ -19,4 +19,4 @@ roles:
         protocol: TCP
         external: 443
         internal: 443
-        public: true
+        public: false

--- a/test-assets/role-manifests/kube/service-headless.yml
+++ b/test-assets/role-manifests/kube/service-headless.yml
@@ -19,4 +19,4 @@ roles:
         protocol: TCP
         external: 443
         internal: 443
-        public: false
+        public: true

--- a/test-assets/role-manifests/model/bosh-run-headless-public-port.yml
+++ b/test-assets/role-manifests/model/bosh-run-headless-public-port.yml
@@ -1,0 +1,15 @@
+---
+roles:
+- name: myrole
+  jobs: []
+  tags: [ headless ]
+  run:
+    scaling:
+      min: 1
+      max: 2
+    exposed-ports:
+      - name: http
+        protocol: TCP
+        external: 80
+        internal: 8080
+        public: true

--- a/test-assets/role-manifests/model/colocated-containers-with-clustered-tag.yml
+++ b/test-assets/role-manifests/model/colocated-containers-with-clustered-tag.yml
@@ -18,7 +18,7 @@ roles:
 
 - name: to-be-colocated
   type: colocated-container
-  tags: [clustered]
+  tags: [headless]
   jobs:
   - name: ntpd
     release_name: ntp

--- a/test-assets/role-manifests/model/colocated-containers-with-port-collision.yml
+++ b/test-assets/role-manifests/model/colocated-containers-with-port-collision.yml
@@ -17,7 +17,7 @@ roles:
       protocol: TCP
       internal: 10000-11000
   tags:
-  - clustered
+  - headless
   jobs:
   - name: new_hostname
     release_name: tor

--- a/testhelpers/helm_helper.go
+++ b/testhelpers/helm_helper.go
@@ -68,7 +68,7 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 		return nil, err
 	}
 	if err = tmpl.Execute(&yamlConfig, actualConfig); err != nil {
-		fmt.Printf("TEMPLATE EXEC FAIL\n%s\nEXEC END\n", string(helmConfig.Bytes()))
+		//fmt.Printf("TEMPLATE EXEC FAIL\n%s\n%s\nEXEC END\n", string(helmConfig.Bytes()), err)
 		return nil, err
 	}
 	return yamlConfig.Bytes(), nil

--- a/testhelpers/helm_helper.go
+++ b/testhelpers/helm_helper.go
@@ -21,12 +21,14 @@ import (
 // to the elements to override.  If they do not contain dots, the map itself
 // is considered the override.
 func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
+
+	basicConfig, err := getBasicConfig()
+	if err != nil {
+		return nil, err
+	}
+
 	actualConfig := map[string]interface{}{
-		"Values": map[string]interface{}{
-			"kube": map[string]interface{}{
-				"hostpath_available": true,
-			},
-		},
+		"Values": basicConfig,
 		"Capabilities": map[string]interface{}{
 			"KubeVersion": map[string]interface{}{
 				"Major": "1",
@@ -39,7 +41,7 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 	}
 	if overrides, ok := config.(map[string]interface{}); ok {
 		for k, v := range overrides {
-			actualConfig = mergeMap(actualConfig, v, strings.Split(k, ".")...)
+			actualConfig = mergeMap(actualConfig, v, 0, strings.Split(k, ".")...)
 		}
 	} else if config != nil {
 		return nil, fmt.Errorf("Invalid config %+v", config)
@@ -111,18 +113,26 @@ func RoundtripKube(node helm.Node) (interface{}, error) {
 
 // mergeMap returns the input map, but with an override applied.  An override
 // is a key path and a value to replace with.
-func mergeMap(obj map[string]interface{}, value interface{}, key ...string) map[string]interface{} {
+func mergeMap(obj map[string]interface{}, value interface{}, index int, key ...string) map[string]interface{} {
 	if len(key) < 1 {
 		panic("No keys")
 	}
-	if len(key) == 1 {
-		obj[key[0]] = value
+	if index > len(key) || index < 0 {
+		panic(fmt.Sprintf("Invalid index %d in keys %v", index, key))
+	}
+	if index == len(key)-1 {
+		obj[key[index]] = value
 		return obj
 	}
-	if _, ok := obj[key[0]]; !ok {
-		obj[key[0]] = make(map[string]interface{})
+	if _, ok := obj[key[index]]; !ok {
+		obj[key[index]] = make(map[string]interface{})
 	}
-	obj[key[0]] = mergeMap(obj[key[0]].(map[string]interface{}), value, key[1:]...)
+	if _, ok := obj[key[index]].(map[string]interface{}); !ok {
+		panic(fmt.Sprintf("Invalid object at %s: is not a map: %+v",
+			strings.Join(key[:index], "."),
+			obj[key[index]]))
+	}
+	obj[key[index]] = mergeMap(obj[key[index]].(map[string]interface{}), value, index+1, key...)
 	return obj
 }
 
@@ -152,4 +162,43 @@ func renderInclude(name string, data interface{}) (string, error) {
 	// first run at this generated a stack overflow.  The fake
 	// simply shows what path/name would have been included.
 	return filepath.Base(name), nil
+}
+
+// getBasicConfig returns the built-in configuration
+func getBasicConfig() (map[string]interface{}, error) {
+	var convertNode func(node helm.Node, path []string) (interface{}, error)
+	convertNode = func(node helm.Node, path []string) (interface{}, error) {
+		switch n := node.(type) {
+		case *helm.Scalar:
+			return n.String(), nil
+		case *helm.List:
+			var values []interface{}
+			for i, v := range n.Values() {
+				converted, err := convertNode(v, append(path, fmt.Sprintf("%d", i)))
+				if err != nil {
+					return nil, err
+				}
+				values = append(values, converted)
+			}
+			return values, nil
+		case *helm.Mapping:
+			values := make(map[string]interface{}, len(n.Names()))
+			for _, k := range n.Names() {
+				converted, err := convertNode(n.Get(k), append(path, k))
+				if err != nil {
+					return nil, err
+				}
+				values[k] = converted
+			}
+			return values, nil
+		default:
+			return nil, fmt.Errorf("Invalid node type at %s", strings.Join(path, "."))
+		}
+	}
+
+	converted, err := convertNode(helm.MakeBasicValues(), nil)
+	if err != nil {
+		return nil, err
+	}
+	return converted.(map[string]interface{}), nil
 }

--- a/testhelpers/helm_helper.go
+++ b/testhelpers/helm_helper.go
@@ -170,7 +170,12 @@ func getBasicConfig() (map[string]interface{}, error) {
 	convertNode = func(node helm.Node, path []string) (interface{}, error) {
 		switch n := node.(type) {
 		case *helm.Scalar:
-			return n.String(), nil
+			var v interface{}
+			err := yaml.Unmarshal([]byte(n.String()), &v)
+			if err != nil {
+				return nil, fmt.Errorf("Error parsing node at %s: %s", strings.Join(path, "."), err)
+			}
+			return v, nil
 		case *helm.List:
 			var values []interface{}
 			for i, v := range n.Values() {

--- a/testhelpers/serialization_helper.go
+++ b/testhelpers/serialization_helper.go
@@ -126,7 +126,7 @@ func isYAMLSubsetInner(assert *assert.Assertions, expected, actual interface{}, 
 		if !assert.Contains(allowedTypes, actualValue.Kind(), "expected YAML path %s to be a %s, but is actually %s", yamlPath, expectedValue.Type(), actualType) {
 			return false
 		}
-		if !assert.Equal(expectedValue.Len(), actualValue.Len(), "expected slice at YAML path %s to have correct length", yamlPath) {
+		if !assert.Len(actualValue.Interface(), expectedValue.Len(), "expected slice at YAML path %s to have correct length", yamlPath) {
 			return false
 		}
 		success := true


### PR DESCRIPTION
This implements the [Pod Management using Role Manifest Tags](https://github.com/SUSE/fissile/wiki/Pod-Management-using-Role-Manifest-Tags) document.

Notable changes:
- We only use statefulset now
- The tags are all changed
- Dev-only roles are no longer a thing (it really hasn't for a while, since we deploy via kube now)
- BOSH roles will actually look at `monit` for the readiness
- For active/passive roles, a command line is used to determine when it's ready (at which point a label is applied to the pod)
- I use lists of constants (since we don't have actual enums in golang) more, and raw strings less.
- For some reason, the old kube stuff was (incorrectly) outputting `externalIPs` as a single string instead of a list

This should probably wait for #352 to land first — that started first, and making that rebase sounds annoying.

/cc @HeavyWombat @zhangtbj as a heads-up.