### PR TITLE
Add configurable annotations to volumes

### DIFF
--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -68,11 +68,12 @@ func getVolumeClaims(role *model.Role, createHelmChart bool) []helm.Node {
 		}
 
 		meta := helm.NewMapping("name", volume.Tag)
-		if volume.Annotations == nil || len(volume.Annotations) == 0 { // default behaviour
-			meta.Add("annotations", helm.NewMapping(VolumeStorageClassAnnotation, storageClass))
-		} else {
-			meta.Add("annotations", volume.Annotations)
+		annotationList := helm.NewMapping()
+		annotationList.Add(VolumeStorageClassAnnotation, storageClass)
+		for key, value := range volume.Annotations {
+			annotationList.Add(key, value)
 		}
+		meta.Add("annotations", annotationList)
 
 		var size string
 		if createHelmChart {

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -68,7 +68,11 @@ func getVolumeClaims(role *model.Role, createHelmChart bool) []helm.Node {
 		}
 
 		meta := helm.NewMapping("name", volume.Tag)
-		meta.Add("annotations", helm.NewMapping(VolumeStorageClassAnnotation, storageClass))
+		if volume.Annotations == nil || len(volume.Annotations) == 0 { // default behaviour
+			meta.Add("annotations", helm.NewMapping(VolumeStorageClassAnnotation, storageClass))
+		} else {
+			meta.Add("annotations", volume.Annotations)
+		}
 
 		var size string
 		if createHelmChart {

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -278,14 +278,14 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 						name: myrole
 						volumeMounts:
 						-
-							name: host-volume
-							mountPath: /sys/fs/cgroup
-						-
 							name: persistent-volume
 							mountPath: /mnt/persistent
 						-
 							name: shared-volume
 							mountPath: /mnt/shared
+						-
+							name: host-volume
+							mountPath: /sys/fs/cgroup
 					volumes:
 					-
 						name: host-volume
@@ -307,6 +307,7 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 					metadata:
 						annotations:
 							volume.beta.kubernetes.io/storage-class: shared
+							volume.beta.kubernetes.io/storage-provisioner: a-company.io/storage-provisioner
 						name: shared-volume
 					spec:
 						accessModes: [ReadWriteMany]

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -240,6 +240,83 @@ func TestStatefulSetVolumesKube(t *testing.T) {
 	testhelpers.IsYAMLSubsetString(assert, expected, actual)
 }
 
+func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	manifest, role := statefulSetTestLoadManifest(assert, "volumes-with-annotation.yml")
+	if manifest == nil || role == nil {
+		return
+	}
+
+	statefulset, _, err := NewStatefulSet(role, ExportSettings{
+		Opinions: model.NewEmptyOpinions(),
+	}, nil)
+	if !assert.NoError(err) {
+		return
+	}
+
+	actual, err := testhelpers.RoundtripKube(statefulset)
+	if !assert.NoError(err) {
+		return
+	}
+
+	expected := `---
+		metadata:
+			name: myrole
+		spec:
+			replicas: 1
+			serviceName: myrole-set
+			template:
+				metadata:
+					labels:
+						skiff-role-name: myrole
+					name: myrole
+				spec:
+					containers:
+					-
+						name: myrole
+						volumeMounts:
+						-
+							name: host-volume
+							mountPath: /sys/fs/cgroup
+						-
+							name: persistent-volume
+							mountPath: /mnt/persistent
+						-
+							name: shared-volume
+							mountPath: /mnt/shared
+					volumes:
+					-
+						name: host-volume
+						hostPath:
+							path: /sys/fs/cgroup
+			volumeClaimTemplates:
+				-
+					metadata:
+						annotations:
+							volume.beta.kubernetes.io/storage-class: a-company-file-gold
+							volume.beta.kubernetes.io/storage-provisioner: a-company.io/storage-provisioner
+						name: persistent-volume
+					spec:
+						accessModes: [ReadWriteOnce]
+						resources:
+							requests:
+								storage: 5G
+				-
+					metadata:
+						annotations:
+							volume.beta.kubernetes.io/storage-class: shared
+						name: shared-volume
+					spec:
+						accessModes: [ReadWriteMany]
+						resources:
+							requests:
+								storage: 40G
+	`
+	testhelpers.IsYAMLSubsetString(assert, expected, actual)
+}
+
 func TestStatefulSetVolumesHelm(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)

--- a/model/roles.go
+++ b/model/roles.go
@@ -134,10 +134,11 @@ type RoleRunScaling struct {
 
 // RoleRunVolume describes a volume to be attached at runtime
 type RoleRunVolume struct {
-	Type VolumeType `yaml:"type"`
-	Path string     `yaml:"path"`
-	Tag  string     `yaml:"tag"`
-	Size int        `yaml:"size"`
+	Type        VolumeType        `yaml:"type"`
+	Path        string            `yaml:"path"`
+	Tag         string            `yaml:"tag"`
+	Size        int               `yaml:"size"`
+	Annotations map[string]string `yaml:"annotations"`
 }
 
 // RoleRunExposedPort describes a port to be available to other roles, or the outside world

--- a/test-assets/role-manifests/kube/volumes-with-annotation.yml
+++ b/test-assets/role-manifests/kube/volumes-with-annotation.yml
@@ -10,26 +10,20 @@ roles:
     scaling:
       min: 1
       max: 2
-    persistent-volumes:
+    volumes:
     - path: /mnt/persistent
+      type: persistent
       tag: persistent-volume
       size: 5 # parsecs
       annotations:
         volume.beta.kubernetes.io/storage-class: a-company-file-gold
         volume.beta.kubernetes.io/storage-provisioner: a-company.io/storage-provisioner
-    shared-volumes:
     - path: /mnt/shared
+      type: shared
       tag: shared-volume
       size: 40 # cakes
       annotations:
-    volumes:
+        volume.beta.kubernetes.io/storage-provisioner: a-company.io/storage-provisioner
     - path: /sys/fs/cgroup
       type: host
       tag: host-volume
-configuration:
-  templates:
-    fox: ((SOME_VAR))
-  variables:
-  - name: ALL_VAR
-    internal: true
-  - name: SOME_VAR

--- a/test-assets/role-manifests/kube/volumes-with-annotation.yml
+++ b/test-assets/role-manifests/kube/volumes-with-annotation.yml
@@ -1,0 +1,35 @@
+---
+roles:
+- name: myrole
+  jobs:
+  - name: tor
+    release_name: tor
+  run:
+    capabilities:
+    - something
+    scaling:
+      min: 1
+      max: 2
+    persistent-volumes:
+    - path: /mnt/persistent
+      tag: persistent-volume
+      size: 5 # parsecs
+      annotations:
+        volume.beta.kubernetes.io/storage-class: a-company-file-gold
+        volume.beta.kubernetes.io/storage-provisioner: a-company.io/storage-provisioner
+    shared-volumes:
+    - path: /mnt/shared
+      tag: shared-volume
+      size: 40 # cakes
+      annotations:
+    volumes:
+    - path: /sys/fs/cgroup
+      type: host
+      tag: host-volume
+configuration:
+  templates:
+    fox: ((SOME_VAR))
+  variables:
+  - name: ALL_VAR
+    internal: true
+  - name: SOME_VAR


### PR DESCRIPTION
Hi, 

This PR contains a new field in the `RoleRunVolume` structure,  to allow persistent and shared
volumes annotations to be customizable.  This is for use cases where the default annotation is not enough for the IaaS, and additional ones are required. Also, the default one, should be allow to be overwritten based on the user needs.