### PR TITLE
Move non-role settings out of sizing to config

### DIFF
--- a/docs/sizing-cleanup.md
+++ b/docs/sizing-cleanup.md
@@ -1,0 +1,48 @@
+# Issue
+
+Parsing the `sizing` section of `values.yaml` is difficult because it
+contains a mix of per-role descriptions and other things: HA, memory,
+cpu.
+
+The extra tuneables should be moved somewhere else.
+
+Example of an old variable setting: `--set sizing.HA=true`
+
+# Implemented change
+
+Moved the non-role-specific settings to the new key `config`.
+
+For example `sizing.HA` becomes `config.HA`.
+
+The keys affected by this change are:
+
+   * `sizing.HA`
+   * `sizing.cpu.limits`
+   * `sizing.cpu.requests`
+   * `sizing.memory.limits`
+   * `sizing.memory.requests`
+
+The only keys left under `sizing` are the per-role descriptions.
+
+Further, to prevent users from accidentally using the old names in
+their overide yaml files, all templates are extended to contain
+guarding statements of the form
+
+```
+    {{- if .Values.FOO }}
+    _moved(FOO): {{ fail "Bad use of moved variable FOO. The new name to use is [FOO]" }}
+    {{- end }}
+```
+
+where `FOO` is one of the keys above, `(FOO)` that key changed to not
+be nested (`.` --> `_`), and `[FOO]` the new key for `FOO`.
+
+Example: `sizing.cpu.limits` to `sizing_cpu_limits`
+
+Fuller example:
+
+```
+    {{- if .Values.sizing.cpu.limits }}
+    _moved_sizing_cpu_limits: {{ fail "Bad use of moved variable sizing.cpu.limits. The new name to use is config.cpu.limits" }}
+    {{- end }}
+```

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -115,6 +115,7 @@ func generalCheck(role *model.Role, controller *helm.Mapping, settings ExportSet
 		controller.Add(guardVariable, fail, helm.Block(block))
 	}
 
+	controller.Sort()
 	return nil
 }
 

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -3,6 +3,7 @@ package kube
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/SUSE/fissile/helm"
 	"github.com/SUSE/fissile/model"
@@ -27,6 +28,10 @@ func NewDeployment(role *model.Role, settings ExportSettings, grapher util.Model
 	deployment := newKubeConfig("extensions/v1beta1", "Deployment", role.Name, helm.Comment(role.GetLongDescription()))
 	deployment.Add("spec", spec)
 	err = replicaCheck(role, deployment, svc, settings)
+	if err != nil {
+		return nil, nil, err
+	}
+	err = generalCheck(role, deployment, settings)
 	return deployment, svc, err
 }
 
@@ -79,6 +84,43 @@ func addAffinityRules(role *model.Role, spec *helm.Mapping, settings ExportSetti
 	return nil
 }
 
+// generalCheck adds common guards to the pod described by the
+// controller. This only applies to helm charts, not basic kube
+// definitions.
+func generalCheck(role *model.Role, controller *helm.Mapping, settings ExportSettings) error {
+	if !settings.CreateHelmChart {
+		return nil
+	}
+
+	// The global config keys found under `sizing` in
+	// `values.yaml` (HA, cpu, memory) were moved out of that
+	// hierarchy into `config`. This gives `sizing` a uniform
+	// structure, containing only the per-role descriptions. It
+	// also means that we now have to guard ourselves against use
+	// of the old keys. Here we add the necessary guard
+	// conditions.
+
+	for _, key := range []string{
+		"HA",
+		"cpu.limits",
+		"cpu.requests",
+		"memory.limits",
+		"memory.requests",
+	} {
+		guardVariable := fmt.Sprintf("_moved_sizing_%s", strings.Replace(key, ".", "_", -1))
+		block := fmt.Sprintf("if .Values.sizing.%s", key)
+		fail := fmt.Sprintf(`{{ fail "Bad use of moved variable sizing.%s. The new name to use is config.%s" }}`,
+			key, key)
+
+		controller.Add(guardVariable, fail, helm.Block(block))
+	}
+
+	return nil
+}
+
+// replicaCheck adds various guards to validate the number of replicas
+// for the pod described by the controller. It further adds the
+// replicas specification itself as well.
 func replicaCheck(role *model.Role, controller *helm.Mapping, service helm.Node, settings ExportSettings) error {
 	spec := controller.Get("spec").(*helm.Mapping)
 
@@ -97,7 +139,7 @@ func replicaCheck(role *model.Role, controller *helm.Mapping, service helm.Node,
 	count := fmt.Sprintf(".Values.sizing.%s.count", roleName)
 	if role.Run.Scaling.HA != role.Run.Scaling.Min {
 		// Under HA use HA count if the user hasn't explicitly modified the default count
-		count = fmt.Sprintf("{{ if and .Values.sizing.HA (eq (int %s) %d) -}} %d {{- else -}} {{ %s }} {{- end }}",
+		count = fmt.Sprintf("{{ if and .Values.config.HA (eq (int %s) %d) -}} %d {{- else -}} {{ %s }} {{- end }}",
 			count, role.Run.Scaling.Min, role.Run.Scaling.HA, count)
 	} else {
 		count = "{{ " + count + " }}"
@@ -120,7 +162,7 @@ func replicaCheck(role *model.Role, controller *helm.Mapping, service helm.Node,
 			fail := fmt.Sprintf(`{{ fail "%s must have at least %d instances for HA" }}`, roleName, role.Run.Scaling.HA)
 			count := fmt.Sprintf(".Values.sizing.%s.count", roleName)
 			// If count != Min then count must be >= HA
-			block := fmt.Sprintf("if and .Values.sizing.HA (and (ne (int %s) %d) (lt (int %s) %d))",
+			block := fmt.Sprintf("if and .Values.config.HA (and (ne (int %s) %d) (lt (int %s) %d))",
 				count, role.Run.Scaling.Min, count, role.Run.Scaling.HA)
 			controller.Add("_minHAReplicas", fail, helm.Block(block))
 		}

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -95,7 +95,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 	assert.Equal(deployment.Get("metadata", "name").String(), "role")
 
 	t.Run("Defaults", func(t *testing.T) {
-		t.Parallel()
+		// t.Parallel()
 		// Rendering fails with defaults, template needs information
 		// about sizing and the like.
 		_, err = testhelpers.RenderNode(deployment, nil)
@@ -103,8 +103,38 @@ func TestNewDeploymentHelm(t *testing.T) {
 			`template: :9:17: executing "" at <fail "role must have...>: error calling fail: role must have at least 1 instances`)
 	})
 
+	t.Run("Configured, not enough replicas", func(t *testing.T) {
+		// t.Parallel()
+		config := map[string]interface{}{
+			"Values.sizing.role.count":                 "0",
+			"Values.sizing.role.affinity.nodeAffinity": "snafu",
+			"Values.sizing.role.capabilities":          []interface{}{},
+			"Values.kube.registry.hostname":            "docker.suse.fake",
+			"Values.kube.organization":                 "splat",
+			"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX":    "domestic",
+		}
+		_, err = testhelpers.RenderNode(deployment, config)
+		assert.EqualError(err,
+			`template: :9:17: executing "" at <fail "role must have...>: error calling fail: role must have at least 1 instances`)
+	})
+
+	t.Run("Configured, too many replicas", func(t *testing.T) {
+		// t.Parallel()
+		config := map[string]interface{}{
+			"Values.sizing.role.count":                 "10",
+			"Values.sizing.role.affinity.nodeAffinity": "snafu",
+			"Values.sizing.role.capabilities":          []interface{}{},
+			"Values.kube.registry.hostname":            "docker.suse.fake",
+			"Values.kube.organization":                 "splat",
+			"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX":    "domestic",
+		}
+		_, err = testhelpers.RenderNode(deployment, config)
+		assert.EqualError(err,
+			`template: :5:17: executing "" at <fail "role cannot ha...>: error calling fail: role cannot have more than 1 instances`)
+	})
+
 	t.Run("Configured", func(t *testing.T) {
-		t.Parallel()
+		// t.Parallel()
 		config := map[string]interface{}{
 			"Values.sizing.role.count":                 "1",
 			"Values.sizing.role.affinity.nodeAffinity": "snafu",

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -133,6 +133,61 @@ func TestNewDeploymentHelm(t *testing.T) {
 			`template: :5:17: executing "" at <fail "role cannot ha...>: error calling fail: role cannot have more than 1 instances`)
 	})
 
+	t.Run("Configured, bad key sizing.HA", func(t *testing.T) {
+		// t.Parallel()
+		config := map[string]interface{}{
+			"Values.sizing.HA":         "true",
+			"Values.sizing.role.count": "1",
+		}
+		_, err = testhelpers.RenderNode(deployment, config)
+		assert.EqualError(err,
+			`template: :13:21: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.HA. The new name to use is config.HA`)
+	})
+
+	t.Run("Configured, bad key sizing.memory.limits", func(t *testing.T) {
+		// t.Parallel()
+		config := map[string]interface{}{
+			"Values.sizing.memory.limits": "true",
+			"Values.sizing.role.count":    "1",
+		}
+		_, err = testhelpers.RenderNode(deployment, config)
+		assert.EqualError(err,
+			`template: :25:32: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.memory.limits. The new name to use is config.memory.limits`)
+	})
+
+	t.Run("Configured, bad key sizing.memory.requests", func(t *testing.T) {
+		// t.Parallel()
+		config := map[string]interface{}{
+			"Values.sizing.memory.requests": "true",
+			"Values.sizing.role.count":      "1",
+		}
+		_, err = testhelpers.RenderNode(deployment, config)
+		assert.EqualError(err,
+			`template: :29:34: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests`)
+	})
+
+	t.Run("Configured, bad key sizing.cpu.limits", func(t *testing.T) {
+		// t.Parallel()
+		config := map[string]interface{}{
+			"Values.sizing.cpu.limits": "true",
+			"Values.sizing.role.count": "1",
+		}
+		_, err = testhelpers.RenderNode(deployment, config)
+		assert.EqualError(err,
+			`template: :17:29: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.cpu.limits. The new name to use is config.cpu.limits`)
+	})
+
+	t.Run("Configured, bad key sizing.cpu.requests", func(t *testing.T) {
+		// t.Parallel()
+		config := map[string]interface{}{
+			"Values.sizing.cpu.requests": "true",
+			"Values.sizing.role.count":   "1",
+		}
+		_, err = testhelpers.RenderNode(deployment, config)
+		assert.EqualError(err,
+			`template: :21:31: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.cpu.requests. The new name to use is config.cpu.requests`)
+	})
+
 	t.Run("Configured", func(t *testing.T) {
 		// t.Parallel()
 		config := map[string]interface{}{

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -48,10 +48,10 @@ func NewPodTemplate(role *model.Role, settings ExportSettings, grapher util.Mode
 		if settings.CreateHelmChart {
 			requests.Add("memory",
 				helm.NewNode(fmt.Sprintf("{{ int .Values.sizing.%s.memory.request }}Mi", roleVarName),
-					helm.Block(fmt.Sprintf("if and .Values.sizing.memory.requests .Values.sizing.%s.memory.request", roleVarName))))
+					helm.Block(fmt.Sprintf("if and .Values.config.memory.requests .Values.sizing.%s.memory.request", roleVarName))))
 			limits.Add("memory",
 				helm.NewNode(fmt.Sprintf("{{ int .Values.sizing.%s.memory.limit }}Mi", roleVarName),
-					helm.Block(fmt.Sprintf("if and .Values.sizing.memory.limits .Values.sizing.%s.memory.limit", roleVarName))))
+					helm.Block(fmt.Sprintf("if and .Values.config.memory.limits .Values.sizing.%s.memory.limit", roleVarName))))
 		} else {
 			if role.Run.Memory != nil {
 				if role.Run.Memory.Request != nil {
@@ -67,10 +67,10 @@ func NewPodTemplate(role *model.Role, settings ExportSettings, grapher util.Mode
 		if settings.CreateHelmChart {
 			requests.Add("cpu",
 				helm.NewNode(fmt.Sprintf("{{ int .Values.sizing.%s.cpu.request }}m", roleVarName),
-					helm.Block(fmt.Sprintf("if and .Values.sizing.cpu.requests .Values.sizing.%s.cpu.request", roleVarName))))
+					helm.Block(fmt.Sprintf("if and .Values.config.cpu.requests .Values.sizing.%s.cpu.request", roleVarName))))
 			limits.Add("cpu",
 				helm.NewNode(fmt.Sprintf("{{ int .Values.sizing.%s.cpu.limit }}m", roleVarName),
-					helm.Block(fmt.Sprintf("if and .Values.sizing.cpu.limits .Values.sizing.%s.cpu.limit", roleVarName))))
+					helm.Block(fmt.Sprintf("if and .Values.config.cpu.limits .Values.sizing.%s.cpu.limit", roleVarName))))
 		} else {
 			if role.Run.CPU != nil {
 				if role.Run.CPU.Request != nil {

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1858,15 +1858,14 @@ func TestPodMemoryHelmActive(t *testing.T) {
 	assert.NotNil(pod)
 
 	config := map[string]interface{}{
-		"Values.kube.registry.hostname":         "R",
-		"Values.kube.organization":              "O",
+		"Values.config.memory.limits":           "true",
+		"Values.config.memory.requests":         "true",
 		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
+		"Values.kube.organization":              "O",
+		"Values.kube.registry.hostname":         "R",
 		"Values.sizing.pre_role.capabilities":   []interface{}{},
-
-		"Values.sizing.memory.requests":         "true",
-		"Values.sizing.pre_role.memory.request": "1",
-		"Values.sizing.memory.limits":           "true",
 		"Values.sizing.pre_role.memory.limit":   "10",
+		"Values.sizing.pre_role.memory.request": "1",
 	}
 
 	actual, err := testhelpers.RoundtripNode(pod, config)
@@ -2046,15 +2045,14 @@ func TestPodCPUHelmActive(t *testing.T) {
 	assert.NotNil(pod)
 
 	config := map[string]interface{}{
-		"Values.kube.registry.hostname":         "R",
-		"Values.kube.organization":              "O",
+		"Values.config.cpu.limits":              "true",
+		"Values.config.cpu.requests":            "true",
 		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
+		"Values.kube.organization":              "O",
+		"Values.kube.registry.hostname":         "R",
 		"Values.sizing.pre_role.capabilities":   []interface{}{},
-
-		"Values.sizing.cpu.requests":         "true",
-		"Values.sizing.pre_role.cpu.request": "1",
-		"Values.sizing.cpu.limits":           "true",
-		"Values.sizing.pre_role.cpu.limit":   "10",
+		"Values.sizing.pre_role.cpu.limit":      "10",
+		"Values.sizing.pre_role.cpu.request":    "1",
 	}
 
 	actual, err := testhelpers.RoundtripNode(pod, config)

--- a/kube/values.go
+++ b/kube/values.go
@@ -57,19 +57,20 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	secrets.Sort()
 	secrets.Merge(generated.Sort())
 
-	memSizing := helm.NewMapping()
-	memSizing.Add("requests", false, helm.Comment("Flag to activate memory requests"))
-	memSizing.Add("limits", false, helm.Comment("Flag to activate memory limits"))
+	memConfig := helm.NewMapping()
+	memConfig.Add("requests", false, helm.Comment("Flag to activate memory requests"))
+	memConfig.Add("limits", false, helm.Comment("Flag to activate memory limits"))
 
-	cpuSizing := helm.NewMapping()
-	cpuSizing.Add("requests", false, helm.Comment("Flag to activate cpu requests"))
-	cpuSizing.Add("limits", false, helm.Comment("Flag to activate cpu limits"))
+	cpuConfig := helm.NewMapping()
+	cpuConfig.Add("requests", false, helm.Comment("Flag to activate cpu requests"))
+	cpuConfig.Add("limits", false, helm.Comment("Flag to activate cpu limits"))
+
+	config := helm.NewMapping()
+	config.Add("HA", false, helm.Comment("Flag to activate high-availability mode"))
+	config.Add("memory", memConfig, helm.Comment("Global memory configuration"))
+	config.Add("cpu", cpuConfig, helm.Comment("Global CPU configuration"))
 
 	sizing := helm.NewMapping()
-	sizing.Add("HA", false, helm.Comment("Flag to activate high-availability mode"))
-	sizing.Add("memory", memSizing, helm.Comment("Global memory configuration"))
-	sizing.Add("cpu", cpuSizing, helm.Comment("Global CPU configuration"))
-
 	for _, role := range settings.RoleManifest.Roles {
 		if role.IsDevRole() || role.Run.FlightStage == model.FlightStageManual {
 			continue
@@ -167,7 +168,6 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 		entry.Add("affinity", helm.NewMapping(), helm.Comment("Node affinity rules can be specified here"))
 
 		sizing.Add(makeVarName(role.Name), entry.Sort(), helm.Comment(role.GetLongDescription()))
-
 	}
 
 	registry := settings.Registry
@@ -197,6 +197,7 @@ func MakeValues(settings ExportSettings) (helm.Node, error) {
 	}
 
 	values := helm.NewMapping()
+	values.Add("config", config.Sort())
 	values.Add("env", env.Sort())
 	values.Add("sizing", sizing.Sort())
 	values.Add("secrets", secrets)

--- a/testhelpers/helm_helper.go
+++ b/testhelpers/helm_helper.go
@@ -147,6 +147,6 @@ func renderInclude(name string, data interface{}) (string, error) {
 	// require adding the handling of `associated` templates.  A
 	// first run at this generated a stack overflow.  The fake
 	// simply shows what path/name would have been included.
-	name = filepath.Base(name)
-	return name, nil
+	base := filepath.Base(name)
+	return base, nil
 }


### PR DESCRIPTION
Ref: https://trello.com/c/7xGqgWkI/671-3-make-sizing-section-of-valuesyaml-uniform

Moved non-role sizing keys to config.
    
- Modified output for values.yaml
- Updated references in the generated templates
- Added guards against the old keys to the generated templates.
- Updated existing tests
- Added documentation about the sizing cleanup.
- Added tests triggering the new guards against old variable names.
- Added more tests for the replica guards.

:warning: Disabled parallel execution. Ran into data race deep in the template engine when having more than 2 to 3 parallel sub tests in the deployment tests. Render tweak, new variable for result instead of overwriting the argument (did not help with the race).

