### PR TITLE
Only use external ips for non loadbalanced mode

### DIFF
--- a/kube/service.go
+++ b/kube/service.go
@@ -146,16 +146,13 @@ func newService(role *model.Role, serviceType newServiceType, settings ExportSet
 	}
 	spec.Add("selector", selector)
 
-	// All services should use ClusterIP except the public one which is overwritten below
-	spec.Add("type", "ClusterIP")
-
 	if serviceType == newServiceTypeHeadless {
 		spec.Add("clusterIP", "None")
 	}
 	if serviceType == newServiceTypePublic {
 		if settings.CreateHelmChart {
 			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}", helm.Block("if not .Values.services.loadbalanced"))
-			spec.Add("type", "{{ if .Values.services.loadbalanced }} LoadBalancer {{ else }} ClusterIP {{ end }}")
+			spec.Add("type", "LoadBalancer", helm.Block("if .Values.services.loadbalanced"))
 		} else {
 			spec.Add("externalIPs", []string{"192.168.77.77"})
 		}

--- a/kube/service.go
+++ b/kube/service.go
@@ -146,21 +146,16 @@ func newService(role *model.Role, serviceType newServiceType, settings ExportSet
 	}
 	spec.Add("selector", selector)
 
-	if settings.CreateHelmChart {
-		spec.Add("type", "{{ if .Values.services.loadbalanced }} LoadBalancer {{ else }} ClusterIP {{ end }}")
-	} else {
-		spec.Add("type", "ClusterIP")
-	}
+	// All services should use ClusterIP except the public one which is overwritten below
+	spec.Add("type", "ClusterIP")
+
 	if serviceType == newServiceTypeHeadless {
-		if settings.CreateHelmChart {
-			spec.Add("clusterIP", "None", helm.Block("if not .Values.services.loadbalanced"))
-		} else {
-			spec.Add("clusterIP", "None")
-		}
+		spec.Add("clusterIP", "None")
 	}
 	if serviceType == newServiceTypePublic {
 		if settings.CreateHelmChart {
-			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}")
+			spec.Add("externalIPs", "{{ .Values.kube.external_ips | toJson }}", helm.Block("if not .Values.services.loadbalanced"))
+			spec.Add("type", "{{ if .Values.services.loadbalanced }} LoadBalancer {{ else }} ClusterIP {{ end }}")
 		} else {
 			spec.Add("externalIPs", []string{"192.168.77.77"})
 		}

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -145,7 +145,7 @@ func TestServiceHelm(t *testing.T) {
 					targetPort: "https"
 				selector:
 					skiff-role-name: "myrole"
-				type:	LoadBalancer
+				type:	ClusterIP
 		`, actual)
 	})
 }
@@ -251,6 +251,7 @@ func TestHeadlessServiceHelm(t *testing.T) {
 			metadata:
 				name: "myrole-set"
 			spec:
+				clusterIP: "None"
 				ports:
 				-	name: "http"
 					port: 80
@@ -262,7 +263,7 @@ func TestHeadlessServiceHelm(t *testing.T) {
 					targetPort: 0
 				selector:
 					skiff-role-name: "myrole"
-				type:	LoadBalancer
+				type:	ClusterIP
 		`, actual)
 	})
 }
@@ -350,7 +351,7 @@ func TestPublicServiceHelm(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
 			"Values.services.loadbalanced": "true",
-			"Values.kube.external_ips":     "",
+			"Values.kube.external_ips":     "[127.0.0.1,127.0.0.2]",
 		}
 
 		actual, err := testhelpers.RoundtripNode(service, config)
@@ -361,7 +362,6 @@ func TestPublicServiceHelm(t *testing.T) {
 			metadata:
 				name: "myrole-public"
 			spec:
-				externalIPs: ""
 				ports:
 				-	name: "https"
 					port: 443
@@ -470,11 +470,6 @@ func TestActivePassiveService(t *testing.T) {
 													skiff-role-active: "true"
 												type: ClusterIP
 										`
-										switch variant {
-										case withHelmLoadBalancer:
-											expected = strings.Replace(expected, "type: ClusterIP", "type: LoadBalancer", 1)
-											expected = strings.Replace(expected, "clusterIP: None", "", 1)
-										}
 										testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
 									}
 								}
@@ -508,10 +503,6 @@ func TestActivePassiveService(t *testing.T) {
 												skiff-role-active: "true"
 											type: ClusterIP
 									`
-									switch variant {
-									case withHelmLoadBalancer:
-										expected = strings.Replace(expected, "type: ClusterIP", "type: LoadBalancer", 1)
-									}
 									testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
 								}
 							}
@@ -540,6 +531,7 @@ func TestActivePassiveService(t *testing.T) {
 									switch variant {
 									case withHelmLoadBalancer:
 										expected = strings.Replace(expected, "type: ClusterIP", "type: LoadBalancer", 1)
+										expected = strings.Replace(expected, "externalIPs: [ 192.0.2.42 ]", "", 1)
 									case withKube:
 										expected = strings.Replace(expected, "192.0.2.42", "192.168.77.77", 1)
 									}

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -71,7 +71,6 @@ func TestServiceKube(t *testing.T) {
 				targetPort: https
 			selector:
 				skiff-role-name: myrole
-			type: ClusterIP
 	`, actual)
 }
 
@@ -116,7 +115,6 @@ func TestServiceHelm(t *testing.T) {
 					targetPort: "https"
 				selector:
 					skiff-role-name: "myrole"
-				type:	ClusterIP
 		`, actual)
 	})
 
@@ -145,7 +143,6 @@ func TestServiceHelm(t *testing.T) {
 					targetPort: "https"
 				selector:
 					skiff-role-name: "myrole"
-				type:	ClusterIP
 		`, actual)
 	})
 }
@@ -185,7 +182,6 @@ func TestHeadlessServiceKube(t *testing.T) {
 				targetPort: 0
 			selector:
 				skiff-role-name: myrole
-			type: ClusterIP
 			clusterIP: None
 	`, actual)
 }
@@ -233,7 +229,6 @@ func TestHeadlessServiceHelm(t *testing.T) {
 					targetPort: 0
 				selector:
 					skiff-role-name: "myrole"
-				type:	ClusterIP
 		`, actual)
 	})
 
@@ -263,7 +258,6 @@ func TestHeadlessServiceHelm(t *testing.T) {
 					targetPort: 0
 				selector:
 					skiff-role-name: "myrole"
-				type:	ClusterIP
 		`, actual)
 	})
 }
@@ -298,7 +292,6 @@ func TestPublicServiceKube(t *testing.T) {
 				targetPort: https
 			selector:
 				skiff-role-name: myrole
-			type: ClusterIP
 	`, actual)
 }
 
@@ -343,11 +336,10 @@ func TestPublicServiceHelm(t *testing.T) {
 					targetPort: "https"
 				selector:
 					skiff-role-name: "myrole"
-				type:	ClusterIP
 		`, actual)
 	})
 
-	t.Run("LoadBalanced", func(t *testing.T) {
+	t.Run("LoadBalancer", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
 			"Values.services.loadbalanced": "true",
@@ -468,7 +460,6 @@ func TestActivePassiveService(t *testing.T) {
 												selector:
 													skiff-role-name: myrole
 													skiff-role-active: "true"
-												type: ClusterIP
 										`
 										testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
 									}
@@ -501,7 +492,6 @@ func TestActivePassiveService(t *testing.T) {
 											selector:
 												skiff-role-name: myrole
 												skiff-role-active: "true"
-											type: ClusterIP
 									`
 									testhelpers.IsYAMLEqualString(assert.New(t), expected, actual)
 								}
@@ -526,12 +516,10 @@ func TestActivePassiveService(t *testing.T) {
 											selector:
 												skiff-role-name: myrole
 												skiff-role-active: "true"
-											type: ClusterIP
 									`
 									switch variant {
 									case withHelmLoadBalancer:
-										expected = strings.Replace(expected, "type: ClusterIP", "type: LoadBalancer", 1)
-										expected = strings.Replace(expected, "externalIPs: [ 192.0.2.42 ]", "", 1)
+										expected = strings.Replace(expected, "externalIPs: [ 192.0.2.42 ]", "type: LoadBalancer", 1)
 									case withKube:
 										expected = strings.Replace(expected, "192.0.2.42", "192.168.77.77", 1)
 									}

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -99,7 +99,6 @@ func TestStatefulSetPorts(t *testing.T) {
 					targetPort: 0
 				selector:
 					skiff-role-name: myrole
-				type: ClusterIP
 				clusterIP: None
 		-
 			# This is the private service port
@@ -117,7 +116,6 @@ func TestStatefulSetPorts(t *testing.T) {
 						targetPort: https
 				selector:
 					skiff-role-name: myrole
-				type: ClusterIP
 		-
 			# This is the public service port
 			metadata:
@@ -130,7 +128,6 @@ func TestStatefulSetPorts(t *testing.T) {
 						targetPort: https
 				selector:
 					skiff-role-name: myrole
-				type: ClusterIP
 		-
 			# This is the actual StatefulSet
 			metadata:
@@ -228,7 +225,6 @@ func TestStatefulSetServices(t *testing.T) {
 									targetPort: 0
 								selector:
 									skiff-role-name: myrole
-								type: ClusterIP
 							`, actual)
 						}
 						if assert.NotNil(t, publicService, "Public service not found") {
@@ -258,7 +254,6 @@ func TestStatefulSetServices(t *testing.T) {
 									targetPort: https
 								selector:
 									skiff-role-name: myrole
-								type: ClusterIP
 							`, actual)
 						}
 						if variant == "headless" {
@@ -294,7 +289,6 @@ func TestStatefulSetServices(t *testing.T) {
 									targetPort: https
 								selector:
 									skiff-role-name: myrole
-								type: ClusterIP
 							`, actual)
 						}
 					})


### PR DESCRIPTION
Automatically provisioning load balancers in Azure (and likely other container services) was broken because of two issues:

* load balancers were being created for non-public services
* external IPs were being defined for public services even though a load balancer was requested

These changes only use `externalIP`s if `loadbalanced == False`, and only request load balancers for `-public` services. A public service is created if the role manifest's `exposed-port` definition has `public: true`


In the second commit I simplified the `ClusterIP` setting since it's the default. It wraps the loadbalancer type in a block rather than the if/else statement. I feel that's simpler, although it's less obvious for the `ClusterIP` setting because that's not explicit any more. If there's any objections I can remove that commit from the PR because it doesn't change functionality.