### PR TITLE
Fix the generated guard conditions.

### DIFF
--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -104,21 +104,13 @@ func generalCheck(role *model.Role, controller *helm.Mapping, settings ExportSet
 	// (2) The `and` operator is not short cuircuited, it evals all of its arguments
 	// Thus `and FOO FOO.BAR` will not work either
 
+	fail := `{{ fail "Bad use of moved variable sizing.HA. The new name to use is config.HA" }}`
+	controller.Add("_moved_sizing_HA", fail, helm.Block("if .Values.sizing.HA"))
+
 	for _, key := range []string{
-		"HA",
 		"cpu",
 		"memory",
 	} {
-		if key == "HA" {
-			guardVariable := fmt.Sprintf("_moved_sizing_%s", key)
-			block := fmt.Sprintf("if .Values.sizing.%s", key)
-			fail := fmt.Sprintf(`{{ fail "Bad use of moved variable sizing.%s. The new name to use is config.%s" }}`,
-				key, key)
-
-			controller.Add(guardVariable, fail, helm.Block(block))
-			continue
-		}
-
 		// requests, limits - More complex to avoid limitations of the go templating system.
 		// Guard on the main variable and then use a guarded value for the child.
 		// The else branch is present in case we happen to get roles named `cpu` or `memory`.

--- a/kube/deployment.go
+++ b/kube/deployment.go
@@ -3,7 +3,6 @@ package kube
 import (
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/SUSE/fissile/helm"
 	"github.com/SUSE/fissile/model"
@@ -99,20 +98,41 @@ func generalCheck(role *model.Role, controller *helm.Mapping, settings ExportSet
 	// also means that we now have to guard ourselves against use
 	// of the old keys. Here we add the necessary guard
 	// conditions.
+	//
+	// Note. The construction shown for requests and limits is used because of
+	// (1) When FOO is nil you cannot check for FOO.BAR, for any BAR.
+	// (2) The `and` operator is not short cuircuited, it evals all of its arguments
+	// Thus `and FOO FOO.BAR` will not work either
 
 	for _, key := range []string{
 		"HA",
-		"cpu.limits",
-		"cpu.requests",
-		"memory.limits",
-		"memory.requests",
+		"cpu",
+		"memory",
 	} {
-		guardVariable := fmt.Sprintf("_moved_sizing_%s", strings.Replace(key, ".", "_", -1))
-		block := fmt.Sprintf("if .Values.sizing.%s", key)
-		fail := fmt.Sprintf(`{{ fail "Bad use of moved variable sizing.%s. The new name to use is config.%s" }}`,
-			key, key)
+		if key == "HA" {
+			guardVariable := fmt.Sprintf("_moved_sizing_%s", key)
+			block := fmt.Sprintf("if .Values.sizing.%s", key)
+			fail := fmt.Sprintf(`{{ fail "Bad use of moved variable sizing.%s. The new name to use is config.%s" }}`,
+				key, key)
 
-		controller.Add(guardVariable, fail, helm.Block(block))
+			controller.Add(guardVariable, fail, helm.Block(block))
+			continue
+		}
+
+		// requests, limits - More complex to avoid limitations of the go templating system.
+		// Guard on the main variable and then use a guarded value for the child.
+		// The else branch is present in case we happen to get roles named `cpu` or `memory`.
+
+		for _, subkey := range []string{
+			"limits",
+			"requests",
+		} {
+			guardVariable := fmt.Sprintf("_moved_sizing_%s_%s", key, subkey)
+			block := fmt.Sprintf("if .Values.sizing.%s", key)
+			fail := fmt.Sprintf(`{{ if .Values.sizing.%s.%s }} {{ fail "Bad use of moved variable sizing.%s.%s. The new name to use is config.%s.%s" }} {{else}} ok {{end}}`,
+				key, subkey, key, subkey, key, subkey)
+			controller.Add(guardVariable, fail, helm.Block(block))
+		}
 	}
 
 	controller.Sort()

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -98,7 +98,10 @@ func TestNewDeploymentHelm(t *testing.T) {
 		t.Parallel()
 		// Rendering fails with defaults, template needs information
 		// about sizing and the like.
-		_, err := testhelpers.RenderNode(deployment, nil)
+		config := map[string]interface{}{
+			"Values.sizing.role.count": nil,
+		}
+		_, err := testhelpers.RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :9:17: executing "" at <fail "role must have...>: error calling fail: role must have at least 1 instances`)
 	})

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -152,7 +152,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 		}
 		_, err := testhelpers.RenderNode(deployment, config)
 		assert.EqualError(err,
-			`template: :25:32: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.memory.limits. The new name to use is config.memory.limits`)
+			`template: :25:70: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.memory.limits. The new name to use is config.memory.limits`)
 	})
 
 	t.Run("Configured, bad key sizing.memory.requests", func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 		}
 		_, err := testhelpers.RenderNode(deployment, config)
 		assert.EqualError(err,
-			`template: :29:34: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests`)
+			`template: :29:74: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests`)
 	})
 
 	t.Run("Configured, bad key sizing.cpu.limits", func(t *testing.T) {
@@ -174,7 +174,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 		}
 		_, err := testhelpers.RenderNode(deployment, config)
 		assert.EqualError(err,
-			`template: :17:29: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.cpu.limits. The new name to use is config.cpu.limits`)
+			`template: :17:64: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.cpu.limits. The new name to use is config.cpu.limits`)
 	})
 
 	t.Run("Configured, bad key sizing.cpu.requests", func(t *testing.T) {
@@ -185,7 +185,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 		}
 		_, err := testhelpers.RenderNode(deployment, config)
 		assert.EqualError(err,
-			`template: :21:31: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.cpu.requests. The new name to use is config.cpu.requests`)
+			`template: :21:68: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.cpu.requests. The new name to use is config.cpu.requests`)
 	})
 
 	t.Run("Configured", func(t *testing.T) {

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/SUSE/fissile/testhelpers"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -792,6 +794,7 @@ func TestPodGetEnvVarsFromConfigSecretsHelm(t *testing.T) {
 		config := map[string]interface{}{
 			"Chart.Version":                          "CV",
 			"Values.kube.secrets_generation_counter": "SGC",
+			"Values.secrets.A_SECRET":                "",
 		}
 
 		ev, err := getEnvVarsFromConfigs(cv, settings)
@@ -953,7 +956,10 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserOptional(t *testing.T) {
 
 	t.Run("Missing", func(t *testing.T) {
 		t.Parallel()
-		actual, err := testhelpers.RoundtripNode(ev, nil)
+		config := map[string]interface{}{
+			"Values.env.SOMETHING": nil,
+		}
+		actual, err := testhelpers.RoundtripNode(ev, config)
 		if !assert.NoError(err) {
 			return
 		}
@@ -1010,10 +1016,21 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserRequired(t *testing.T) {
 			},
 		},
 	})
+	require.NoError(t, err)
 
 	t.Run("Missing", func(t *testing.T) {
 		t.Parallel()
-		_, err = testhelpers.RenderNode(ev, nil)
+		_, err := testhelpers.RenderNode(ev, nil)
+		assert.EqualError(err,
+			`template: :7:62: executing "" at <.Values.env.SOMETHIN...>: can't evaluate field SOMETHING in type interface {}`)
+	})
+
+	t.Run("Undefined", func(t *testing.T) {
+		t.Parallel()
+		config := map[string]interface{}{
+			"Values.env.SOMETHING": nil,
+		}
+		_, err := testhelpers.RenderNode(ev, config)
 		assert.EqualError(err,
 			`template: :7:12: executing "" at <required "SOMETHING ...>: error calling required: SOMETHING configuration missing`)
 	})
@@ -1787,10 +1804,12 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 	assert.NotNil(pod)
 
 	config := map[string]interface{}{
+		"Values.config.memory.requests":         nil,
 		"Values.kube.registry.hostname":         "R",
 		"Values.kube.organization":              "O",
 		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
 		"Values.sizing.pre_role.capabilities":   []interface{}{},
+		"Values.sizing.pre_role.memory.request": nil,
 	}
 
 	actual, err := testhelpers.RoundtripNode(pod, config)
@@ -1974,10 +1993,12 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 	assert.NotNil(pod)
 
 	config := map[string]interface{}{
-		"Values.kube.registry.hostname":         "R",
-		"Values.kube.organization":              "O",
+		"Values.config.cpu.requests":            nil,
 		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
+		"Values.kube.organization":              "O",
+		"Values.kube.registry.hostname":         "R",
 		"Values.sizing.pre_role.capabilities":   []interface{}{},
+		"Values.sizing.pre_role.cpu.request":    nil,
 	}
 
 	actual, err := testhelpers.RoundtripNode(pod, config)

--- a/kube/secret_test.go
+++ b/kube/secret_test.go
@@ -186,7 +186,7 @@ func TestMakeSecretsHelm(t *testing.T) {
 		// not having a proper (non-nil) value.
 
 		config := map[string]interface{}{
-			"Values.secrets.const":  nil,
+			"Values.secrets.const": nil,
 		}
 
 		_, err := testhelpers.RenderNode(secret, config)

--- a/kube/secret_test.go
+++ b/kube/secret_test.go
@@ -169,11 +169,27 @@ func TestMakeSecretsHelm(t *testing.T) {
 	t.Run("Missing", func(t *testing.T) {
 		t.Parallel()
 		// config - helm only
-		// Render with defaults (is expected to) fail(s) due to a
-		// number of guards (secrets.FOO, FOO a variable) not having a
-		// proper (non-nil) value.
+		// Render with defaults (is expected to) fail(s) due
+		// to a number of guards (secrets.FOO, FOO a variable)
+		// not being present at all.
 
-		_, err = testhelpers.RenderNode(secret, nil)
+		_, err := testhelpers.RenderNode(secret, nil)
+		assert.EqualError(err,
+			`template: :6:61: executing "" at <.Values.secrets.cons...>: can't evaluate field const in type interface {}`)
+	})
+
+	t.Run("Undefined", func(t *testing.T) {
+		t.Parallel()
+		// config - helm only
+		// Render with defaults (is expected to) fail(s) due
+		// to a number of guards (secrets.FOO, FOO a variable)
+		// not having a proper (non-nil) value.
+
+		config := map[string]interface{}{
+			"Values.secrets.const":  nil,
+		}
+
+		_, err := testhelpers.RenderNode(secret, config)
 		assert.EqualError(err,
 			`template: :6:12: executing "" at <required "secrets.co...>: error calling required: secrets.const has not been set`)
 	})

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -92,7 +92,10 @@ func TestServiceHelm(t *testing.T) {
 
 	t.Run("ClusterIP", func(t *testing.T) {
 		t.Parallel()
-		actual, err := testhelpers.RoundtripNode(service, nil)
+		config := map[string]interface{}{
+			"Values.services.loadbalanced": nil,
+		}
+		actual, err := testhelpers.RoundtripNode(service, config)
 		require.NoError(t, err)
 		testhelpers.IsYAMLEqualString(assert, `---
 			apiVersion: "v1"
@@ -205,7 +208,10 @@ func TestHeadlessServiceHelm(t *testing.T) {
 
 	t.Run("ClusterIP", func(t *testing.T) {
 		t.Parallel()
-		actual, err := testhelpers.RoundtripNode(service, nil)
+		config := map[string]interface{}{
+			"Values.services.loadbalanced": nil,
+		}
+		actual, err := testhelpers.RoundtripNode(service, config)
 		require.NoError(t, err)
 		testhelpers.IsYAMLEqualString(assert, `---
 			apiVersion: "v1"
@@ -314,7 +320,8 @@ func TestPublicServiceHelm(t *testing.T) {
 	t.Run("ClusterIP", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
-			"Values.kube.external_ips": "[127.0.0.1,127.0.0.2]",
+			"Values.kube.external_ips":     "[127.0.0.1,127.0.0.2]",
+			"Values.services.loadbalanced": nil,
 		}
 
 		actual, err := testhelpers.RoundtripNode(service, config)

--- a/kube/stateful_set.go
+++ b/kube/stateful_set.go
@@ -44,7 +44,10 @@ func NewStatefulSet(role *model.Role, settings ExportSettings, grapher util.Mode
 	statefulSet := newKubeConfig("apps/v1beta1", "StatefulSet", role.Name, helm.Comment(role.GetLongDescription()))
 	statefulSet.Add("spec", spec)
 	err = replicaCheck(role, statefulSet, svcList, settings)
-
+	if err != nil {
+		return nil, nil, err
+	}
+	err = generalCheck(role, statefulSet, settings)
 	return statefulSet, svcList, err
 }
 

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -336,12 +336,14 @@ func TestStatefulSetVolumesHelm(t *testing.T) {
 	}
 
 	config := map[string]interface{}{
+		"Values.env.ALL_VAR":                                "",
+		"Values.kube.registry.hostname":                     "",
+		"Values.kube.storage_class.persistent":              "persistent",
+		"Values.kube.storage_class.shared":                  "shared",
+		"Values.sizing.myrole.capabilities":                 []interface{}{},
 		"Values.sizing.myrole.count":                        "1",
 		"Values.sizing.myrole.disk_sizes.persistent_volume": "5",
 		"Values.sizing.myrole.disk_sizes.shared_volume":     "40",
-		"Values.sizing.myrole.capabilities":                 []interface{}{},
-		"Values.kube.storage_class.shared":                  "shared",
-		"Values.kube.storage_class.persistent":              "persistent",
 	}
 
 	actual, err := testhelpers.RoundtripNode(statefulset, config)
@@ -406,9 +408,13 @@ func TestStatefulSetVolumesHelm(t *testing.T) {
 
 	// Check that not having hostpath disables the hostpath volume
 	overrides := map[string]interface{}{
-		"Values.kube.hostpath_available":    false,
-		"Values.sizing.myrole.count":        "1",
-		"Values.sizing.myrole.capabilities": []interface{}{},
+		"Values.env.ALL_VAR":                                "",
+		"Values.kube.hostpath_available":                    false,
+		"Values.kube.registry.hostname":                     "",
+		"Values.kube.storage_class.persistent":              "persistent",
+		"Values.sizing.myrole.capabilities":                 []interface{}{},
+		"Values.sizing.myrole.count":                        "1",
+		"Values.sizing.myrole.disk_sizes.persistent_volume": "5",
 	}
 	actual, err = testhelpers.RoundtripNode(statefulset, overrides)
 	if !assert.NoError(err) {

--- a/testhelpers/helm_helper.go
+++ b/testhelpers/helm_helper.go
@@ -33,6 +33,9 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 				"Minor": "8",
 			},
 		},
+		"Template": map[string]interface{}{
+			"BasePath": "",
+		},
 	}
 	if overrides, ok := config.(map[string]interface{}); ok {
 		for k, v := range overrides {
@@ -57,7 +60,8 @@ func RenderNode(node helm.Node, config interface{}) ([]byte, error) {
 	functions["include"] = renderInclude
 	functions["required"] = renderRequired
 
-	tmpl, err := template.New("").Funcs(functions).Parse(string(helmConfig.Bytes()))
+	// Note: Replicate helm's behaviour on missing keys.
+	tmpl, err := template.New("").Option("missingkey=zero").Funcs(functions).Parse(string(helmConfig.Bytes()))
 
 	if err != nil {
 		//fmt.Printf("TEMPLATE PARSE FAIL\n%s\nPARSE END\n", string(helmConfig.Bytes()))


### PR DESCRIPTION
Cannot check FOO.BAR when FOO is nil.
Cannot `and FOO FOO.BAR` because `and` is not short-circuited.
Matched tests (changed column indices in the error messages)

Ref https://trello.com/c/7xGqgWkI/671-3-make-sizing-section-of-valuesyaml-uniform