### PR TITLE
Drop support for KUBE_SERVICE_DOMAIN_SUFFIX

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -80,12 +80,7 @@ Name | Description
 `DNS_RECORD_NAME` | Hostname of the container
 `IP_ADDRESS` | Primary IP address of the container
 `KUBE_COMPONENT_INDEX` | Numeric index for roles with multiple replicas
-`KUBE_SERVICE_DOMAIN_SUFFIX` | Kubernetes service domain for the deployment
 `KUBERNETES_CLUSTER_DOMAIN` | Kubernetes cluster domain, `cluster.local` by default
-
-The use of `KUBE_SERVICE_DOMAIN_SUFFIX` is deprecated; it should be replaced by
-`$KUBERNETES_NAMESPACE.svc.$KUBERNETES_CLUSTER_DOMAIN`. `KUBERNETES_NAMESPACE` is
-provided by fissile via the helm chart (from the pod's `metadata.namespace` field).
 
 [run.sh]: https://github.com/SUSE/fissile/blob/master/scripts/dockerfiles/run.sh
 

--- a/docs/validator-description.md
+++ b/docs/validator-description.md
@@ -200,7 +200,6 @@ handle these for generic operation of `fissile`. These are:
    * `JWT_SIGNING_PUB`
    * `KUBERNETES_CLUSTER_DOMAIN`
    * `KUBE_COMPONENT_INDEX`
-   * `KUBE_SERVICE_DOMAIN_SUFFIX`
    * `NO_PROXY`
    * `http_proxy`
    * `https_proxy`

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -115,7 +115,6 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.kube.registry.hostname":            "docker.suse.fake",
 			"Values.kube.organization":                 "splat",
 			"Values.env.KUBERNETES_CLUSTER_DOMAIN":     "cluster.local",
-			"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX":    "domestic",
 		}
 		_, err := testhelpers.RenderNode(deployment, config)
 		assert.EqualError(err,
@@ -131,7 +130,6 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.kube.registry.hostname":            "docker.suse.fake",
 			"Values.kube.organization":                 "splat",
 			"Values.env.KUBERNETES_CLUSTER_DOMAIN":     "cluster.local",
-			"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX":    "domestic",
 		}
 		_, err := testhelpers.RenderNode(deployment, config)
 		assert.EqualError(err,
@@ -202,7 +200,6 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.kube.registry.hostname":            "docker.suse.fake",
 			"Values.kube.organization":                 "splat",
 			"Values.env.KUBERNETES_CLUSTER_DOMAIN":     "cluster.local",
-			"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX":    "domestic",
 		}
 
 		actual, err := testhelpers.RoundtripNode(deployment, config)
@@ -250,8 +247,6 @@ func TestNewDeploymentHelm(t *testing.T) {
 								valueFrom:
 									fieldRef:
 										fieldPath: "metadata.namespace"
-							-	name: "KUBE_SERVICE_DOMAIN_SUFFIX"
-								value: "domestic"
 							image: "docker.suse.fake/splat/the_repos-role:bfff10016c4e9e46c9541d35e6bf52054c54e96a"
 							lifecycle:
 								preStop:
@@ -431,13 +426,12 @@ func TestNewDeploymentWithEmptyDirVolume(t *testing.T) {
 	t.Run("Configured", func(t *testing.T) {
 		t.Parallel()
 		config := map[string]interface{}{
-			"Values.sizing.role.count":              "1",
-			"Values.sizing.role.capabilities":       []interface{}{},
-			"Values.sizing.colocated.capabilities":  []interface{}{},
-			"Values.kube.registry.hostname":         "docker.suse.fake",
-			"Values.kube.organization":              "splat",
-			"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
-			"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "domestic",
+			"Values.sizing.role.count":             "1",
+			"Values.sizing.role.capabilities":      []interface{}{},
+			"Values.sizing.colocated.capabilities": []interface{}{},
+			"Values.kube.registry.hostname":        "docker.suse.fake",
+			"Values.kube.organization":             "splat",
+			"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
 		}
 
 		actual, err := testhelpers.RoundtripNode(deployment, config)

--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -167,7 +167,7 @@ func TestJobHelm(t *testing.T) {
 	// - Release.Revision
 	// - Values.kube.registry.hostname
 	// - Values.kube.organization
-	// - Values.env.KUBE_SERVICE_DOMAIN_SUFFIX
+	// - Values.env.KUBERNETES_CLUSTER_DOMAIN
 	// can all be removed without causing an error during render.
 	// The output simply gains <no value>, and empty string.
 	//
@@ -178,13 +178,12 @@ func TestJobHelm(t *testing.T) {
 		"Capabilities.KubeVersion.Major": "1",
 		"Capabilities.KubeVersion.Minor": "6",
 		// Fake location for a fake `secrets.yaml`.
-		"Template.BasePath":                     fakeTemplateDir,
-		"Release.Revision":                      "42",
-		"Values.kube.registry.hostname":         "docker.suse.fake",
-		"Values.kube.organization":              "splat",
-		"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
-		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "domestic",
-		"Values.sizing.pre_role.capabilities":   []interface{}{},
+		"Template.BasePath":                    fakeTemplateDir,
+		"Release.Revision":                     "42",
+		"Values.kube.registry.hostname":        "docker.suse.fake",
+		"Values.kube.organization":             "splat",
+		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
+		"Values.sizing.pre_role.capabilities":  []interface{}{},
 	}
 
 	actual, err := testhelpers.RoundtripNode(job, config)
@@ -213,8 +212,6 @@ func TestJobHelm(t *testing.T) {
 							valueFrom:
 								fieldRef:
 									fieldPath: "metadata.namespace"
-						-	name: "KUBE_SERVICE_DOMAIN_SUFFIX"
-							value: "domestic"
 						image: "docker.suse.fake/splat/the_repos-pre-role:b0668a0daba46290566d99ee97d7b45911a53293"
 						lifecycle:
 							preStop:

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -1748,11 +1748,10 @@ func TestPodPreFlightHelm(t *testing.T) {
 	assert.NotNil(pod)
 
 	config := map[string]interface{}{
-		"Values.kube.registry.hostname":         "R",
-		"Values.kube.organization":              "O",
-		"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
-		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
-		"Values.sizing.pre_role.capabilities":   []interface{}{},
+		"Values.kube.registry.hostname":        "R",
+		"Values.kube.organization":             "O",
+		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
+		"Values.sizing.pre_role.capabilities":  []interface{}{},
 	}
 
 	actual, err := testhelpers.RoundtripNode(pod, config)
@@ -1775,8 +1774,6 @@ func TestPodPreFlightHelm(t *testing.T) {
 					valueFrom:
 						fieldRef:
 							fieldPath: "metadata.namespace"
-				-	name: "KUBE_SERVICE_DOMAIN_SUFFIX"
-					value: "KSDS"
 				image: "R/O/theRepo-pre-role:b0668a0daba46290566d99ee97d7b45911a53293"
 				lifecycle:
 					preStop:
@@ -1853,11 +1850,10 @@ func TestPodPostFlightHelm(t *testing.T) {
 	assert.NotNil(pod)
 
 	config := map[string]interface{}{
-		"Values.kube.registry.hostname":         "R",
-		"Values.kube.organization":              "O",
-		"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
-		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
-		"Values.sizing.post_role.capabilities":  []interface{}{},
+		"Values.kube.registry.hostname":        "R",
+		"Values.kube.organization":             "O",
+		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
+		"Values.sizing.post_role.capabilities": []interface{}{},
 	}
 
 	actual, err := testhelpers.RoundtripNode(pod, config)
@@ -1880,8 +1876,6 @@ func TestPodPostFlightHelm(t *testing.T) {
 					valueFrom:
 						fieldRef:
 							fieldPath: "metadata.namespace"
-				-	name: "KUBE_SERVICE_DOMAIN_SUFFIX"
-					value: "KSDS"
 				image: "R/O/theRepo-post-role:e9f459d3c3576bf1129a6b18ca2763f73fa19645"
 				lifecycle:
 					preStop:
@@ -1970,7 +1964,6 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 		"Values.kube.registry.hostname":         "R",
 		"Values.kube.organization":              "O",
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
-		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
 		"Values.sizing.pre_role.capabilities":   []interface{}{},
 		"Values.sizing.pre_role.memory.request": nil,
 	}
@@ -1995,8 +1988,6 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 					valueFrom:
 						fieldRef:
 							fieldPath: "metadata.namespace"
-				-	name: "KUBE_SERVICE_DOMAIN_SUFFIX"
-					value: "KSDS"
 				image: "R/O/theRepo-pre-role:b0668a0daba46290566d99ee97d7b45911a53293"
 				lifecycle:
 					preStop:
@@ -2045,7 +2036,6 @@ func TestPodMemoryHelmActive(t *testing.T) {
 		"Values.config.memory.limits":           "true",
 		"Values.config.memory.requests":         "true",
 		"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
-		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
 		"Values.kube.organization":              "O",
 		"Values.kube.registry.hostname":         "R",
 		"Values.sizing.pre_role.capabilities":   []interface{}{},
@@ -2073,8 +2063,6 @@ func TestPodMemoryHelmActive(t *testing.T) {
 					valueFrom:
 						fieldRef:
 							fieldPath: "metadata.namespace"
-				-	name: "KUBE_SERVICE_DOMAIN_SUFFIX"
-					value: "KSDS"
 				image: "R/O/theRepo-pre-role:b0668a0daba46290566d99ee97d7b45911a53293"
 				lifecycle:
 					preStop:
@@ -2161,13 +2149,12 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 	assert.NotNil(pod)
 
 	config := map[string]interface{}{
-		"Values.config.cpu.requests":            nil,
-		"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
-		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
-		"Values.kube.organization":              "O",
-		"Values.kube.registry.hostname":         "R",
-		"Values.sizing.pre_role.capabilities":   []interface{}{},
-		"Values.sizing.pre_role.cpu.request":    nil,
+		"Values.config.cpu.requests":           nil,
+		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
+		"Values.kube.organization":             "O",
+		"Values.kube.registry.hostname":        "R",
+		"Values.sizing.pre_role.capabilities":  []interface{}{},
+		"Values.sizing.pre_role.cpu.request":   nil,
 	}
 
 	actual, err := testhelpers.RoundtripNode(pod, config)
@@ -2190,8 +2177,6 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 					valueFrom:
 						fieldRef:
 							fieldPath: "metadata.namespace"
-				-	name: "KUBE_SERVICE_DOMAIN_SUFFIX"
-					value: "KSDS"
 				image: "R/O/theRepo-pre-role:b0668a0daba46290566d99ee97d7b45911a53293"
 				lifecycle:
 					preStop:
@@ -2237,15 +2222,14 @@ func TestPodCPUHelmActive(t *testing.T) {
 	assert.NotNil(pod)
 
 	config := map[string]interface{}{
-		"Values.config.cpu.limits":              "true",
-		"Values.config.cpu.requests":            "true",
-		"Values.env.KUBERNETES_CLUSTER_DOMAIN":  "cluster.local",
-		"Values.env.KUBE_SERVICE_DOMAIN_SUFFIX": "KSDS",
-		"Values.kube.organization":              "O",
-		"Values.kube.registry.hostname":         "R",
-		"Values.sizing.pre_role.capabilities":   []interface{}{},
-		"Values.sizing.pre_role.cpu.limit":      "10",
-		"Values.sizing.pre_role.cpu.request":    "1",
+		"Values.config.cpu.limits":             "true",
+		"Values.config.cpu.requests":           "true",
+		"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
+		"Values.kube.organization":             "O",
+		"Values.kube.registry.hostname":        "R",
+		"Values.sizing.pre_role.capabilities":  []interface{}{},
+		"Values.sizing.pre_role.cpu.limit":     "10",
+		"Values.sizing.pre_role.cpu.request":   "1",
 	}
 
 	actual, err := testhelpers.RoundtripNode(pod, config)
@@ -2268,8 +2252,6 @@ func TestPodCPUHelmActive(t *testing.T) {
 					valueFrom:
 						fieldRef:
 							fieldPath: "metadata.namespace"
-				-	name: "KUBE_SERVICE_DOMAIN_SUFFIX"
-					value: "KSDS"
 				image: "R/O/theRepo-pre-role:b0668a0daba46290566d99ee97d7b45911a53293"
 				lifecycle:
 					preStop:

--- a/model/mustache.go
+++ b/model/mustache.go
@@ -131,11 +131,6 @@ func builtins() ConfigurationVariableSlice {
 			Internal: true,
 		},
 		&ConfigurationVariable{
-			Name:     "KUBE_SERVICE_DOMAIN_SUFFIX",
-			Type:     CVTypeUser, // The user can override this
-			Internal: true,
-		},
-		&ConfigurationVariable{
 			Name:     "KUBERNETES_CLUSTER_DOMAIN",
 			Type:     CVTypeUser, // The user can override this
 			Internal: true,

--- a/model/mustache_test.go
+++ b/model/mustache_test.go
@@ -19,7 +19,7 @@ func TestMain(m *testing.M) {
 func TestParsing(t *testing.T) {
 	// Arrange
 	assert := assert.New(t)
-	template := "((FISSILE_IDENTITY_SCHEME))://((#FISSILE_IDENTITY_EXTERNAL_HOST))((FISSILE_INSTANCE_ID)).((FISSILE_IDENTITY_EXTERNAL_HOST)):((FISSILE_IDENTITY_EXTERNAL_PORT))((/FISSILE_IDENTITY_EXTERNAL_HOST))((^FISSILE_IDENTITY_EXTERNAL_HOST))scf.uaa-int.((FISSILE_SERVICE_DOMAIN_SUFFIX)):8443((/FISSILE_IDENTITY_EXTERNAL_HOST))"
+	template := "((FISSILE_IDENTITY_SCHEME))://((#FISSILE_IDENTITY_EXTERNAL_HOST))((FISSILE_INSTANCE_ID)).((FISSILE_IDENTITY_EXTERNAL_HOST)):((FISSILE_IDENTITY_EXTERNAL_PORT))((/FISSILE_IDENTITY_EXTERNAL_HOST))((^FISSILE_IDENTITY_EXTERNAL_HOST))scf.uaa-int.uaa.svc.((FISSILE_CLUSTER_DOMAIN)):8443((/FISSILE_IDENTITY_EXTERNAL_HOST))"
 
 	// Act
 	pieces, err := parseTemplate(template)
@@ -29,7 +29,7 @@ func TestParsing(t *testing.T) {
 	assert.Contains(pieces, "FISSILE_INSTANCE_ID")
 	assert.Contains(pieces, "FISSILE_IDENTITY_EXTERNAL_HOST")
 	assert.Contains(pieces, "FISSILE_IDENTITY_EXTERNAL_PORT")
-	assert.Contains(pieces, "FISSILE_SERVICE_DOMAIN_SUFFIX")
+	assert.Contains(pieces, "FISSILE_CLUSTER_DOMAIN")
 	assert.NotContains(pieces, "FOO")
 }
 
@@ -52,7 +52,7 @@ func TestRoleVariables(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, vars)
 
-	expected := []string{"HOME", "FOO", "BAR", "KUBERNETES_CLUSTER_DOMAIN", "KUBE_SERVICE_DOMAIN_SUFFIX", "PELERINUL"}
+	expected := []string{"HOME", "FOO", "BAR", "KUBERNETES_CLUSTER_DOMAIN", "PELERINUL"}
 	sort.Strings(expected)
 	var actual []string
 	for _, variable := range vars {

--- a/scripts/dockerfiles/run.sh
+++ b/scripts/dockerfiles/run.sh
@@ -93,9 +93,6 @@ if test "${#KUBE_COMPONENT_INDEX}" -gt 4 ; then
     | gawk -vRS=".|" ' BEGIN { chars="bcdfghjklmnpqrstvwxz0123456789" } { n = n * length(chars) + index(chars, RT) - 1 } END { print n }'
   )"
 fi
-if test -z "${KUBE_SERVICE_DOMAIN_SUFFIX:-}" && grep -E --quiet '^search' /etc/resolv.conf ; then
-  export KUBE_SERVICE_DOMAIN_SUFFIX="$(awk '/^search/ { print $2 }' /etc/resolv.conf)"
-fi
 if test -z "${KUBERNETES_CLUSTER_DOMAIN:-}" && grep -E --quiet '^search' /etc/resolv.conf ; then
   export KUBERNETES_CLUSTER_DOMAIN="$(perl -ne 'print $1 if /^search.* svc\.(\S+)/' /etc/resolv.conf)"
 fi


### PR DESCRIPTION
It can always be replaced by $KUBERNETES_NAMESPACE.svc.$KUBERNETES_CLUSTER_DOMAIN

Please create new `5.3.0` tag on the merge commit