### PR TITLE
Move MakeBasicValues from helm to kube package

### DIFF
--- a/helm/config.go
+++ b/helm/config.go
@@ -593,36 +593,3 @@ func (enc *Encoder) writeNode(node Node, prefix *string, label string, emptyLine
 		enc.pendingNewline = emptyLines
 	}
 }
-
-// MakeBasicValues returns a Mapping with the default values that do not depend
-// on any configuration.  This is exported so the tests from other packages can
-// access them.
-func MakeBasicValues() *Mapping {
-	return NewMapping(
-		"kube", NewMapping(
-			"external_ips", NewList(),
-			"secrets_generation_counter", NewNode(1, Comment("Increment this counter to rotate all generated secrets")),
-			"storage_class", NewMapping("persistent", "persistent", "shared", "shared"),
-			"hostpath_available", NewNode(false, Comment("Whether HostPath volume mounts are available")),
-			"registry", NewMapping(
-				"hostname", "docker.io",
-				"username", "",
-				"password", ""),
-			"organization", "",
-			"auth", nil),
-		"config", NewMapping(
-			"HA", NewNode(false, Comment("Flag to activate high-availability mode")),
-			"memory", NewNode(NewMapping(
-				"requests", NewNode(false, Comment("Flag to activate memory requests")),
-				"limits", NewNode(false, Comment("Flag to activate memory limits")),
-			), Comment("Global memory configuration")),
-			"cpu", NewNode(NewMapping(
-				"requests", NewNode(false, Comment("Flag to activate cpu requests")),
-				"limits", NewNode(false, Comment("Flag to activate cpu limits")),
-			), Comment("Global CPU configuration"))),
-		"env", NewMapping(),
-		"sizing", NewMapping(),
-		"secrets", NewMapping(),
-		"services", NewMapping(
-			"loadbalanced", false))
-}

--- a/kube/deployment_test.go
+++ b/kube/deployment_test.go
@@ -101,7 +101,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 		config := map[string]interface{}{
 			"Values.sizing.role.count": nil,
 		}
-		_, err := testhelpers.RenderNode(deployment, config)
+		_, err := RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :9:17: executing "" at <fail "role must have...>: error calling fail: role must have at least 1 instances`)
 	})
@@ -116,7 +116,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.kube.organization":                 "splat",
 			"Values.env.KUBERNETES_CLUSTER_DOMAIN":     "cluster.local",
 		}
-		_, err := testhelpers.RenderNode(deployment, config)
+		_, err := RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :9:17: executing "" at <fail "role must have...>: error calling fail: role must have at least 1 instances`)
 	})
@@ -131,7 +131,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.kube.organization":                 "splat",
 			"Values.env.KUBERNETES_CLUSTER_DOMAIN":     "cluster.local",
 		}
-		_, err := testhelpers.RenderNode(deployment, config)
+		_, err := RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :5:17: executing "" at <fail "role cannot ha...>: error calling fail: role cannot have more than 1 instances`)
 	})
@@ -142,7 +142,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.sizing.HA":         "true",
 			"Values.sizing.role.count": "1",
 		}
-		_, err := testhelpers.RenderNode(deployment, config)
+		_, err := RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :13:21: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.HA. The new name to use is config.HA`)
 	})
@@ -153,7 +153,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.sizing.memory.limits": "true",
 			"Values.sizing.role.count":    "1",
 		}
-		_, err := testhelpers.RenderNode(deployment, config)
+		_, err := RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :25:70: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.memory.limits. The new name to use is config.memory.limits`)
 	})
@@ -164,7 +164,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.sizing.memory.requests": "true",
 			"Values.sizing.role.count":      "1",
 		}
-		_, err := testhelpers.RenderNode(deployment, config)
+		_, err := RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :29:74: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.memory.requests. The new name to use is config.memory.requests`)
 	})
@@ -175,7 +175,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.sizing.cpu.limits": "true",
 			"Values.sizing.role.count": "1",
 		}
-		_, err := testhelpers.RenderNode(deployment, config)
+		_, err := RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :17:64: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.cpu.limits. The new name to use is config.cpu.limits`)
 	})
@@ -186,7 +186,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.sizing.cpu.requests": "true",
 			"Values.sizing.role.count":   "1",
 		}
-		_, err := testhelpers.RenderNode(deployment, config)
+		_, err := RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :21:68: executing "" at <fail "Bad use of mov...>: error calling fail: Bad use of moved variable sizing.cpu.requests. The new name to use is config.cpu.requests`)
 	})
@@ -202,7 +202,7 @@ func TestNewDeploymentHelm(t *testing.T) {
 			"Values.env.KUBERNETES_CLUSTER_DOMAIN":     "cluster.local",
 		}
 
-		actual, err := testhelpers.RoundtripNode(deployment, config)
+		actual, err := RoundtripNode(deployment, config)
 		if !assert.NoError(err) {
 			return
 		}
@@ -418,7 +418,7 @@ func TestNewDeploymentWithEmptyDirVolume(t *testing.T) {
 		config := map[string]interface{}{
 			"Values.sizing.role.count": nil,
 		}
-		_, err := testhelpers.RenderNode(deployment, config)
+		_, err := RenderNode(deployment, config)
 		assert.EqualError(err,
 			`template: :9:17: executing "" at <fail "role must have...>: error calling fail: role must have at least 1 instances`)
 	})
@@ -434,7 +434,7 @@ func TestNewDeploymentWithEmptyDirVolume(t *testing.T) {
 			"Values.env.KUBERNETES_CLUSTER_DOMAIN": "cluster.local",
 		}
 
-		actual, err := testhelpers.RoundtripNode(deployment, config)
+		actual, err := RoundtripNode(deployment, config)
 		if !assert.NoError(err) {
 			return
 		}

--- a/kube/job_test.go
+++ b/kube/job_test.go
@@ -52,7 +52,7 @@ func TestJobPreFlight(t *testing.T) {
 	}
 	assert.NotNil(job)
 
-	actual, err := testhelpers.RoundtripKube(job)
+	actual, err := RoundtripKube(job)
 	if !assert.NoError(err) {
 		return
 	}
@@ -89,7 +89,7 @@ func TestJobPostFlight(t *testing.T) {
 	}
 	assert.NotNil(job)
 
-	actual, err := testhelpers.RoundtripKube(job)
+	actual, err := RoundtripKube(job)
 	if !assert.NoError(err) {
 		return
 	}
@@ -127,7 +127,7 @@ func TestJobWithAnnotations(t *testing.T) {
 	}
 	assert.NotNil(job)
 
-	actual, err := testhelpers.RoundtripKube(job)
+	actual, err := RoundtripKube(job)
 	if !assert.NoError(err) {
 		return
 	}
@@ -186,7 +186,7 @@ func TestJobHelm(t *testing.T) {
 		"Values.sizing.pre_role.capabilities":  []interface{}{},
 	}
 
-	actual, err := testhelpers.RoundtripNode(job, config)
+	actual, err := RoundtripNode(job, config)
 	if !assert.NoError(err) {
 		return
 	}

--- a/kube/kube_test.go
+++ b/kube/kube_test.go
@@ -1,4 +1,4 @@
-package testhelpers
+package kube
 
 import (
 	"bytes"
@@ -201,7 +201,7 @@ func getBasicConfig() (map[string]interface{}, error) {
 		}
 	}
 
-	converted, err := convertNode(helm.MakeBasicValues(), nil)
+	converted, err := convertNode(MakeBasicValues(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -106,7 +106,7 @@ func TestPodGetNonClaimVolumes(t *testing.T) {
 	mounts := getNonClaimVolumes(role, true)
 	assert.NotNil(mounts)
 
-	actual, err := testhelpers.RoundtripNode(mounts, map[string]interface{}{
+	actual, err := RoundtripNode(mounts, map[string]interface{}{
 		"Values.kube.hostpath_available": true})
 	if !assert.NoError(err) {
 		return
@@ -229,7 +229,7 @@ func TestPodGetVolumesHelm(t *testing.T) {
 		"Values.sizing.myrole.disk_sizes.shared_volume":     "84",
 	}
 
-	actual, err := testhelpers.RoundtripNode(persistentClaim, config)
+	actual, err := RoundtripNode(persistentClaim, config)
 	if assert.NoError(err) {
 		testhelpers.IsYAMLEqualString(assert, `---
 		metadata:
@@ -245,7 +245,7 @@ func TestPodGetVolumesHelm(t *testing.T) {
 		`, actual)
 	}
 
-	actual, err = testhelpers.RoundtripNode(sharedClaim, config)
+	actual, err = RoundtripNode(sharedClaim, config)
 	if assert.NoError(err) {
 		testhelpers.IsYAMLEqualString(assert, `---
 		metadata:
@@ -277,7 +277,7 @@ func TestPodGetVolumeMounts(t *testing.T) {
 		t.Run(caseName, func(t *testing.T) {
 
 			volumeMountNodes := getVolumeMounts(role, true)
-			volumeMounts, err := testhelpers.RoundtripNode(volumeMountNodes, map[string]interface{}{"Values.kube.hostpath_available": hasHostpath})
+			volumeMounts, err := RoundtripNode(volumeMountNodes, map[string]interface{}{"Values.kube.hostpath_available": hasHostpath})
 			if !assert.NoError(t, err) {
 				return
 			}
@@ -409,7 +409,7 @@ func TestPodGetEnvVarsFromConfigSizingCountKube(t *testing.T) {
 		},
 	})
 
-	actual, err := testhelpers.RoundtripNode(ev, nil)
+	actual, err := RoundtripNode(ev, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -446,7 +446,7 @@ func TestPodGetEnvVarsFromConfigSizingCountHelm(t *testing.T) {
 		"Values.sizing.foo.count": "22",
 	}
 
-	actual, err := testhelpers.RoundtripNode(ev, config)
+	actual, err := RoundtripNode(ev, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -491,7 +491,7 @@ func TestPodGetEnvVarsFromConfigSizingPortsKube(t *testing.T) {
 		},
 	})
 
-	actual, err := testhelpers.RoundtripNode(ev, nil)
+	actual, err := RoundtripNode(ev, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -542,7 +542,7 @@ func TestPodGetEnvVarsFromConfigSizingPortsHelm(t *testing.T) {
 		"Values.sizing.foo.ports.store.count": "22",
 	}
 
-	actual, err := testhelpers.RoundtripNode(ev, config)
+	actual, err := RoundtripNode(ev, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -576,7 +576,7 @@ func TestPodGetEnvVarsFromConfigGenerationCounterKube(t *testing.T) {
 		},
 	})
 
-	actual, err := testhelpers.RoundtripNode(ev, nil)
+	actual, err := RoundtripNode(ev, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -613,7 +613,7 @@ func TestPodGetEnvVarsFromConfigGenerationCounterHelm(t *testing.T) {
 		"Values.kube.secrets_generation_counter": "3",
 	}
 
-	actual, err := testhelpers.RoundtripNode(ev, config)
+	actual, err := RoundtripNode(ev, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -645,7 +645,7 @@ func TestPodGetEnvVarsFromConfigGenerationNameKube(t *testing.T) {
 		},
 	})
 
-	actual, err := testhelpers.RoundtripNode(ev, nil)
+	actual, err := RoundtripNode(ev, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -683,7 +683,7 @@ func TestPodGetEnvVarsFromConfigGenerationNameHelm(t *testing.T) {
 		"Values.kube.secrets_generation_counter": "SGC",
 	}
 
-	actual, err := testhelpers.RoundtripNode(ev, config)
+	actual, err := RoundtripNode(ev, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -715,7 +715,7 @@ func TestPodGetEnvVarsFromConfigSecretsKube(t *testing.T) {
 		},
 	})
 
-	actual, err := testhelpers.RoundtripNode(ev, nil)
+	actual, err := RoundtripNode(ev, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -759,7 +759,7 @@ func TestPodGetEnvVarsFromConfigSecretsHelm(t *testing.T) {
 			return
 		}
 
-		actual, err := testhelpers.RoundtripNode(ev, nil)
+		actual, err := RoundtripNode(ev, nil)
 		if !assert.NoError(err) {
 			return
 		}
@@ -805,7 +805,7 @@ func TestPodGetEnvVarsFromConfigSecretsHelm(t *testing.T) {
 		// Mutation of cv below between tests prevents parallel execution
 
 		t.Run("AsIs", func(t *testing.T) {
-			actual, err := testhelpers.RoundtripNode(ev, config)
+			actual, err := RoundtripNode(ev, config)
 			if !assert.NoError(err) {
 				return
 			}
@@ -828,7 +828,7 @@ func TestPodGetEnvVarsFromConfigSecretsHelm(t *testing.T) {
 				"Values.secrets.A_SECRET": "user's choice",
 			}
 
-			actual, err := testhelpers.RoundtripNode(ev, config)
+			actual, err := RoundtripNode(ev, config)
 			if !assert.NoError(err) {
 				return
 			}
@@ -853,7 +853,7 @@ func TestPodGetEnvVarsFromConfigSecretsHelm(t *testing.T) {
 		}
 
 		t.Run("Immutable", func(t *testing.T) {
-			actual, err := testhelpers.RoundtripNode(ev, config)
+			actual, err := RoundtripNode(ev, config)
 			if !assert.NoError(err) {
 				return
 			}
@@ -895,7 +895,7 @@ func TestPodGetEnvVarsFromConfigNonSecretKube(t *testing.T) {
 			},
 		}, settings)
 
-		actual, err := testhelpers.RoundtripNode(ev, nil)
+		actual, err := RoundtripNode(ev, nil)
 		if !assert.NoError(err) {
 			return
 		}
@@ -918,7 +918,7 @@ func TestPodGetEnvVarsFromConfigNonSecretKube(t *testing.T) {
 			},
 		}, settings)
 
-		actual, err := testhelpers.RoundtripNode(ev, nil)
+		actual, err := RoundtripNode(ev, nil)
 		if !assert.NoError(err) {
 			return
 		}
@@ -959,7 +959,7 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserOptional(t *testing.T) {
 		config := map[string]interface{}{
 			"Values.env.SOMETHING": nil,
 		}
-		actual, err := testhelpers.RoundtripNode(ev, config)
+		actual, err := RoundtripNode(ev, config)
 		if !assert.NoError(err) {
 			return
 		}
@@ -980,7 +980,7 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserOptional(t *testing.T) {
 			"Values.env.SOMETHING": "else",
 		}
 
-		actual, err := testhelpers.RoundtripNode(ev, config)
+		actual, err := RoundtripNode(ev, config)
 		if !assert.NoError(err) {
 			return
 		}
@@ -1020,7 +1020,7 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserRequired(t *testing.T) {
 
 	t.Run("Missing", func(t *testing.T) {
 		t.Parallel()
-		_, err := testhelpers.RenderNode(ev, nil)
+		_, err := RenderNode(ev, nil)
 		assert.EqualError(err,
 			`template: :7:12: executing "" at <required "SOMETHING ...>: error calling required: SOMETHING configuration missing`)
 	})
@@ -1030,7 +1030,7 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserRequired(t *testing.T) {
 		config := map[string]interface{}{
 			"Values.env.SOMETHING": nil,
 		}
-		_, err := testhelpers.RenderNode(ev, config)
+		_, err := RenderNode(ev, config)
 		assert.EqualError(err,
 			`template: :7:12: executing "" at <required "SOMETHING ...>: error calling required: SOMETHING configuration missing`)
 	})
@@ -1041,7 +1041,7 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserRequired(t *testing.T) {
 			"Values.env.SOMETHING": "needed",
 		}
 
-		actual, err := testhelpers.RoundtripNode(ev, config)
+		actual, err := RoundtripNode(ev, config)
 		if !assert.NoError(err) {
 			return
 		}
@@ -1611,7 +1611,7 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 					require.NotNil(t, probe, "No error getting readiness probe but it was nil")
 					t.Run("kube", func(t *testing.T) {
 						t.Parallel()
-						actual, err := testhelpers.RoundtripKube(probe)
+						actual, err := RoundtripKube(probe)
 						if assert.NoError(t, err) {
 							// We use subset testing here because we don't want to bother with the
 							// default timeout lengths
@@ -1620,7 +1620,7 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 					})
 					t.Run("helm", func(t *testing.T) {
 						t.Parallel()
-						actual, err := testhelpers.RoundtripNode(probe, map[string]interface{}{})
+						actual, err := RoundtripNode(probe, map[string]interface{}{})
 						if assert.NoError(t, err) {
 							// We use subset testing here because we don't want to bother with the
 							// default timeout lengths
@@ -1647,7 +1647,7 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 					require.NotNil(t, probe, "No error getting readiness probe but it was nil")
 					t.Run("kube", func(t *testing.T) {
 						t.Parallel()
-						actual, err := testhelpers.RoundtripKube(probe)
+						actual, err := RoundtripKube(probe)
 						if assert.NoError(t, err) {
 							// We use subset testing here because we don't want to bother with the
 							// default timeout lengths
@@ -1656,7 +1656,7 @@ func TestPodGetContainerReadinessProbe(t *testing.T) {
 					})
 					t.Run("helm", func(t *testing.T) {
 						t.Parallel()
-						actual, err := testhelpers.RoundtripNode(probe, map[string]interface{}{})
+						actual, err := RoundtripNode(probe, map[string]interface{}{})
 						if assert.NoError(t, err) {
 							// We use subset testing here because we don't want to bother with the
 							// default timeout lengths
@@ -1712,7 +1712,7 @@ func TestPodPreFlightKube(t *testing.T) {
 	}
 	assert.NotNil(pod)
 
-	actual, err := testhelpers.RoundtripNode(pod, nil)
+	actual, err := RoundtripNode(pod, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -1754,7 +1754,7 @@ func TestPodPreFlightHelm(t *testing.T) {
 		"Values.sizing.pre_role.capabilities":  []interface{}{},
 	}
 
-	actual, err := testhelpers.RoundtripNode(pod, config)
+	actual, err := RoundtripNode(pod, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -1814,7 +1814,7 @@ func TestPodPostFlightKube(t *testing.T) {
 	}
 	assert.NotNil(pod)
 
-	actual, err := testhelpers.RoundtripNode(pod, nil)
+	actual, err := RoundtripNode(pod, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -1856,7 +1856,7 @@ func TestPodPostFlightHelm(t *testing.T) {
 		"Values.sizing.post_role.capabilities": []interface{}{},
 	}
 
-	actual, err := testhelpers.RoundtripNode(pod, config)
+	actual, err := RoundtripNode(pod, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -1918,7 +1918,7 @@ func TestPodMemoryKube(t *testing.T) {
 	}
 	assert.NotNil(pod)
 
-	actual, err := testhelpers.RoundtripNode(pod, nil)
+	actual, err := RoundtripNode(pod, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -1968,7 +1968,7 @@ func TestPodMemoryHelmDisabled(t *testing.T) {
 		"Values.sizing.pre_role.memory.request": nil,
 	}
 
-	actual, err := testhelpers.RoundtripNode(pod, config)
+	actual, err := RoundtripNode(pod, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2043,7 +2043,7 @@ func TestPodMemoryHelmActive(t *testing.T) {
 		"Values.sizing.pre_role.memory.request": "1",
 	}
 
-	actual, err := testhelpers.RoundtripNode(pod, config)
+	actual, err := RoundtripNode(pod, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2107,7 +2107,7 @@ func TestPodCPUKube(t *testing.T) {
 	}
 	assert.NotNil(pod)
 
-	actual, err := testhelpers.RoundtripKube(pod)
+	actual, err := RoundtripKube(pod)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2157,7 +2157,7 @@ func TestPodCPUHelmDisabled(t *testing.T) {
 		"Values.sizing.pre_role.cpu.request":   nil,
 	}
 
-	actual, err := testhelpers.RoundtripNode(pod, config)
+	actual, err := RoundtripNode(pod, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2232,7 +2232,7 @@ func TestPodCPUHelmActive(t *testing.T) {
 		"Values.sizing.pre_role.cpu.request":   "1",
 	}
 
-	actual, err := testhelpers.RoundtripNode(pod, config)
+	actual, err := RoundtripNode(pod, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2296,7 +2296,7 @@ func TestGetSecurityContextCapList(t *testing.T) {
 			return
 		}
 
-		actual, err := testhelpers.RoundtripKube(sc)
+		actual, err := RoundtripKube(sc)
 		if !assert.NoError(err) {
 			return
 		}
@@ -2319,7 +2319,7 @@ func TestGetSecurityContextCapList(t *testing.T) {
 			config := map[string]interface{}{
 				"Values.sizing.myrole.capabilities": []interface{}{},
 			}
-			actual, err := testhelpers.RoundtripNode(sc, config)
+			actual, err := RoundtripNode(sc, config)
 			if !assert.NoError(err) {
 				return
 			}
@@ -2335,7 +2335,7 @@ func TestGetSecurityContextCapList(t *testing.T) {
 			config := map[string]interface{}{
 				"Values.sizing.myrole.capabilities": []interface{}{"ALL"},
 			}
-			actual, err := testhelpers.RoundtripNode(sc, config)
+			actual, err := RoundtripNode(sc, config)
 			if !assert.NoError(err) {
 				return
 			}
@@ -2349,7 +2349,7 @@ func TestGetSecurityContextCapList(t *testing.T) {
 			config := map[string]interface{}{
 				"Values.sizing.myrole.capabilities": []interface{}{"something"},
 			}
-			actual, err := testhelpers.RoundtripNode(sc, config)
+			actual, err := RoundtripNode(sc, config)
 			if !assert.NoError(err) {
 				return
 			}
@@ -2394,7 +2394,7 @@ func TestGetSecurityContextNil(t *testing.T) {
 			config := map[string]interface{}{
 				"Values.sizing.myrole.capabilities": []interface{}{},
 			}
-			actual, err := testhelpers.RoundtripNode(sc, config)
+			actual, err := RoundtripNode(sc, config)
 			if !assert.NoError(err) {
 				return
 			}
@@ -2409,7 +2409,7 @@ func TestGetSecurityContextNil(t *testing.T) {
 			config := map[string]interface{}{
 				"Values.sizing.myrole.capabilities": []interface{}{"ALL"},
 			}
-			actual, err := testhelpers.RoundtripNode(sc, config)
+			actual, err := RoundtripNode(sc, config)
 			if !assert.NoError(err) {
 				return
 			}
@@ -2423,7 +2423,7 @@ func TestGetSecurityContextNil(t *testing.T) {
 			config := map[string]interface{}{
 				"Values.sizing.myrole.capabilities": []interface{}{"something"},
 			}
-			actual, err := testhelpers.RoundtripNode(sc, config)
+			actual, err := RoundtripNode(sc, config)
 			if !assert.NoError(err) {
 				return
 			}
@@ -2459,7 +2459,7 @@ func TestGetSecurityContextPrivileged(t *testing.T) {
 			return
 		}
 
-		actual, err := testhelpers.RoundtripKube(sc)
+		actual, err := RoundtripKube(sc)
 		if !assert.NoError(err) {
 			return
 		}
@@ -2475,7 +2475,7 @@ func TestGetSecurityContextPrivileged(t *testing.T) {
 			return
 		}
 
-		actual, err := testhelpers.RoundtripKube(sc)
+		actual, err := RoundtripKube(sc)
 		if !assert.NoError(err) {
 			return
 		}
@@ -2538,7 +2538,7 @@ func TestPodGetContainerImageNameHelm(t *testing.T) {
 		"Values.kube.organization":      "O",
 	}
 
-	actual, err := testhelpers.RoundtripNode(nameNode, config)
+	actual, err := RoundtripNode(nameNode, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2562,7 +2562,7 @@ func TestPodGetContainerPortsKube(t *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(ports)
 
-	actual, err := testhelpers.RoundtripKube(ports)
+	actual, err := RoundtripKube(ports)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2592,7 +2592,7 @@ func TestPodGetContainerPortsHelm(t *testing.T) {
 	assert.Nil(err)
 	assert.NotNil(ports)
 
-	actual, err := testhelpers.RoundtripNode(ports, nil)
+	actual, err := RoundtripNode(ports, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2626,7 +2626,7 @@ func TestPodGetContainerPortsHelmCountConfigurable(t *testing.T) {
 		"Values.sizing.myrole.ports.tcp_route.count": "5",
 	}
 
-	actual, err := testhelpers.RoundtripNode(ports, config)
+	actual, err := RoundtripNode(ports, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2655,7 +2655,7 @@ func TestPodMakeSecretVarPlain(t *testing.T) {
 
 	sv := makeSecretVar("foo", false)
 
-	actual, err := testhelpers.RoundtripNode(sv, nil)
+	actual, err := RoundtripNode(sv, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2679,7 +2679,7 @@ func TestPodMakeSecretVarGenerated(t *testing.T) {
 		"Values.kube.secrets_generation_counter": "SGC",
 	}
 
-	actual, err := testhelpers.RoundtripNode(sv, config)
+	actual, err := RoundtripNode(sv, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2714,7 +2714,7 @@ func TestPodVolumeTypeEmptyDir(t *testing.T) {
 	// Check non-claim volumes
 	mounts := getNonClaimVolumes(roleManifest.LookupRole("main-role"), true)
 	assert.NotNil(mounts)
-	actual, err := testhelpers.RoundtripNode(mounts, nil)
+	actual, err := RoundtripNode(mounts, nil)
 	if !assert.NoError(err) {
 		return
 	}
@@ -2729,7 +2729,7 @@ func TestPodVolumeTypeEmptyDir(t *testing.T) {
 
 		mounts := getVolumeMounts(role, true)
 		assert.NotNil(mounts)
-		actual, err := testhelpers.RoundtripNode(mounts, nil)
+		actual, err := RoundtripNode(mounts, nil)
 		if !assert.NoError(err) {
 			return
 		}

--- a/kube/rbac_test.go
+++ b/kube/rbac_test.go
@@ -26,7 +26,7 @@ func TestNewRBACAccountKube(t *testing.T) {
 	}
 
 	rbacAccount := resources[0]
-	actualAccount, err := testhelpers.RoundtripKube(rbacAccount)
+	actualAccount, err := RoundtripKube(rbacAccount)
 	if !assert.NoError(err) {
 		return
 	}
@@ -38,7 +38,7 @@ func TestNewRBACAccountKube(t *testing.T) {
 	`, actualAccount)
 
 	rbacRole := resources[1]
-	actualRole, err := testhelpers.RoundtripKube(rbacRole)
+	actualRole, err := RoundtripKube(rbacRole)
 	if !assert.NoError(err) {
 		return
 	}
@@ -81,7 +81,7 @@ func TestNewRBACAccountHelmNoAuth(t *testing.T) {
 	t.Run("NoAuth", func(t *testing.T) {
 		t.Parallel()
 		// config: .Values.kube.auth -- helm only ("", "rbac")
-		actualAccount, err := testhelpers.RoundtripNode(rbacAccount, nil)
+		actualAccount, err := RoundtripNode(rbacAccount, nil)
 		if !assert.NoError(err) {
 			return
 		}
@@ -89,7 +89,7 @@ func TestNewRBACAccountHelmNoAuth(t *testing.T) {
 		`, actualAccount)
 
 		// config: .Values.kube.auth helm only ("", "rbac")
-		actualRole, err := testhelpers.RoundtripNode(rbacRole, nil)
+		actualRole, err := RoundtripNode(rbacRole, nil)
 		if !assert.NoError(err) {
 			return
 		}
@@ -104,7 +104,7 @@ func TestNewRBACAccountHelmNoAuth(t *testing.T) {
 			"Values.kube.auth": "rbac",
 		}
 
-		actualAccount, err := testhelpers.RoundtripNode(rbacAccount, config)
+		actualAccount, err := RoundtripNode(rbacAccount, config)
 		if !assert.NoError(err) {
 			return
 		}
@@ -116,7 +116,7 @@ func TestNewRBACAccountHelmNoAuth(t *testing.T) {
 				name: "the-name"
 		`, actualAccount)
 
-		actualRole, err := testhelpers.RoundtripNode(rbacRole, config)
+		actualRole, err := RoundtripNode(rbacRole, config)
 		if !assert.NoError(err) {
 			return
 		}
@@ -155,7 +155,7 @@ func TestNewRBACRoleKube(t *testing.T) {
 		return
 	}
 
-	actual, err := testhelpers.RoundtripKube(rbacRole)
+	actual, err := RoundtripKube(rbacRole)
 	if !assert.NoError(err) {
 		return
 	}
@@ -200,7 +200,7 @@ func TestNewRBACRoleHelm(t *testing.T) {
 			"Values.kube.auth": "",
 		}
 
-		actual, err := testhelpers.RoundtripNode(rbacRole, config)
+		actual, err := RoundtripNode(rbacRole, config)
 		if !assert.NoError(err) {
 			return
 		}
@@ -215,7 +215,7 @@ func TestNewRBACRoleHelm(t *testing.T) {
 			"Values.kube.auth": "rbac",
 		}
 
-		actual, err := testhelpers.RoundtripNode(rbacRole, config)
+		actual, err := RoundtripNode(rbacRole, config)
 		if !assert.NoError(err) {
 			return
 		}

--- a/kube/registry_credentials_test.go
+++ b/kube/registry_credentials_test.go
@@ -19,7 +19,7 @@ func TestMakeRegistryCredentialsKube(t *testing.T) {
 		return
 	}
 
-	actual, err := testhelpers.RoundtripKube(registryCredentials)
+	actual, err := RoundtripKube(registryCredentials)
 	if !assert.NoError(err) {
 		return
 	}
@@ -51,8 +51,8 @@ func TestMakeRegistryCredentialsHelm(t *testing.T) {
 	pass := "the-password"
 	host := "the-host"
 
-	auth64 := testhelpers.RenderEncodeBase64(fmt.Sprintf("%s:%s", user, pass))
-	dcfg := testhelpers.RenderEncodeBase64(fmt.Sprintf(
+	auth64 := RenderEncodeBase64(fmt.Sprintf("%s:%s", user, pass))
+	dcfg := RenderEncodeBase64(fmt.Sprintf(
 		`{%q:{"username":%q,"password":%q,"auth":%q}}`,
 		host, user, pass, auth64))
 
@@ -62,7 +62,7 @@ func TestMakeRegistryCredentialsHelm(t *testing.T) {
 		"Values.kube.registry.password": pass,
 	}
 
-	actual, err := testhelpers.RoundtripNode(registryCredentials, config)
+	actual, err := RoundtripNode(registryCredentials, config)
 	if !assert.NoError(err) {
 		return
 	}

--- a/kube/secret_test.go
+++ b/kube/secret_test.go
@@ -30,7 +30,7 @@ func TestMakeSecretsEmpty(t *testing.T) {
 		if !assert.NoError(err) {
 			return
 		}
-		actual, err := testhelpers.RoundtripKube(secret)
+		actual, err := RoundtripKube(secret)
 		if !assert.NoError(err) {
 			return
 		}
@@ -45,7 +45,7 @@ func TestMakeSecretsEmpty(t *testing.T) {
 		if !assert.NoError(err) {
 			return
 		}
-		actual, err := testhelpers.RoundtripNode(secret, nil)
+		actual, err := RoundtripNode(secret, nil)
 		if !assert.NoError(err) {
 			return
 		}
@@ -114,13 +114,13 @@ func TestMakeSecretsKube(t *testing.T) {
 		return
 	}
 
-	renderedYAML, err := testhelpers.RenderNode(secret, nil)
+	renderedYAML, err := RenderNode(secret, nil)
 	if !assert.NoError(err) {
 		return
 	}
 
-	varConstB64 := testhelpers.RenderEncodeBase64(testCV["const"].Default.(string))
-	varValuedB64 := testhelpers.RenderEncodeBase64(testCV["valued"].Default.(string))
+	varConstB64 := RenderEncodeBase64(testCV["const"].Default.(string))
+	varValuedB64 := RenderEncodeBase64(testCV["valued"].Default.(string))
 
 	// Check the comments, and also that they are associated with
 	// the correct variables.
@@ -134,7 +134,7 @@ func TestMakeSecretsKube(t *testing.T) {
 	assert.Contains(astring, "# <<<here is jeannie>>>\n  genie: \"\"")
 	assert.Contains(astring, "# <<<helm hidden>>>\n  guinevere: \"\"")
 
-	actual, err := testhelpers.RoundtripKube(secret)
+	actual, err := RoundtripKube(secret)
 	if !assert.NoError(err) {
 		return
 	}
@@ -173,7 +173,7 @@ func TestMakeSecretsHelm(t *testing.T) {
 		// to a number of guards (secrets.FOO, FOO a variable)
 		// not being present at all.
 
-		_, err := testhelpers.RenderNode(secret, nil)
+		_, err := RenderNode(secret, nil)
 		assert.EqualError(err,
 			`template: :6:12: executing "" at <required "secrets.co...>: error calling required: secrets.const has not been set`)
 	})
@@ -189,7 +189,7 @@ func TestMakeSecretsHelm(t *testing.T) {
 			"Values.secrets.const": nil,
 		}
 
-		_, err := testhelpers.RenderNode(secret, config)
+		_, err := RenderNode(secret, config)
 		assert.EqualError(err,
 			`template: :6:12: executing "" at <required "secrets.co...>: error calling required: secrets.const has not been set`)
 	})
@@ -202,11 +202,11 @@ func TestMakeSecretsHelm(t *testing.T) {
 		varValued := "sky high"
 		varGenie := "djinn"
 
-		varConstB64 := testhelpers.RenderEncodeBase64(varConst)
-		varDescB64 := testhelpers.RenderEncodeBase64(varDesc)
-		varMinB64 := testhelpers.RenderEncodeBase64(varMin)
-		varValuedB64 := testhelpers.RenderEncodeBase64(varValued)
-		varGenieB64 := testhelpers.RenderEncodeBase64(varGenie)
+		varConstB64 := RenderEncodeBase64(varConst)
+		varDescB64 := RenderEncodeBase64(varDesc)
+		varMinB64 := RenderEncodeBase64(varMin)
+		varValuedB64 := RenderEncodeBase64(varValued)
+		varGenieB64 := RenderEncodeBase64(varGenie)
 
 		config := map[string]interface{}{
 			"Values.secrets.const":  varConst,
@@ -216,7 +216,7 @@ func TestMakeSecretsHelm(t *testing.T) {
 			"Values.secrets.genie":  varGenie,
 		}
 
-		renderedYAML, err := testhelpers.RenderNode(secret, config)
+		renderedYAML, err := RenderNode(secret, config)
 		if !assert.NoError(err) {
 			return
 		}
@@ -236,7 +236,7 @@ func TestMakeSecretsHelm(t *testing.T) {
 
 		// And check overall structure
 
-		actual, err := testhelpers.RoundtripNode(secret, config)
+		actual, err := RoundtripNode(secret, config)
 		if !assert.NoError(err) {
 			return
 		}

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -54,7 +54,7 @@ func TestServiceKube(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, service)
 
-	actual, err := testhelpers.RoundtripKube(service)
+	actual, err := RoundtripKube(service)
 	require.NoError(t, err)
 	testhelpers.IsYAMLSubsetString(assert, `---
 		metadata:
@@ -96,7 +96,7 @@ func TestServiceHelm(t *testing.T) {
 		config := map[string]interface{}{
 			"Values.services.loadbalanced": nil,
 		}
-		actual, err := testhelpers.RoundtripNode(service, config)
+		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
 		testhelpers.IsYAMLEqualString(assert, `---
 			apiVersion: "v1"
@@ -124,7 +124,7 @@ func TestServiceHelm(t *testing.T) {
 			"Values.services.loadbalanced": "true",
 		}
 
-		actual, err := testhelpers.RoundtripNode(service, config)
+		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
 		testhelpers.IsYAMLEqualString(assert, `---
 			apiVersion: "v1"
@@ -163,7 +163,7 @@ func TestHeadlessServiceKube(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, service)
 
-	actual, err := testhelpers.RoundtripKube(service)
+	actual, err := RoundtripKube(service)
 	require.NoError(t, err)
 	testhelpers.IsYAMLSubsetString(assert, `---
 		metadata:
@@ -209,7 +209,7 @@ func TestHeadlessServiceHelm(t *testing.T) {
 		config := map[string]interface{}{
 			"Values.services.loadbalanced": nil,
 		}
-		actual, err := testhelpers.RoundtripNode(service, config)
+		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
 		testhelpers.IsYAMLEqualString(assert, `---
 			apiVersion: "v1"
@@ -238,7 +238,7 @@ func TestHeadlessServiceHelm(t *testing.T) {
 			"Values.services.loadbalanced": "true",
 		}
 
-		actual, err := testhelpers.RoundtripNode(service, config)
+		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
 		testhelpers.IsYAMLEqualString(assert, `---
 			apiVersion: "v1"
@@ -278,7 +278,7 @@ func TestPublicServiceKube(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, service)
 
-	actual, err := testhelpers.RoundtripKube(service)
+	actual, err := RoundtripKube(service)
 	require.NoError(t, err)
 	testhelpers.IsYAMLSubsetString(assert, `---
 		metadata:
@@ -320,7 +320,7 @@ func TestPublicServiceHelm(t *testing.T) {
 			"Values.services.loadbalanced": nil,
 		}
 
-		actual, err := testhelpers.RoundtripNode(service, config)
+		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
 		testhelpers.IsYAMLEqualString(assert, `---
 			apiVersion: "v1"
@@ -346,7 +346,7 @@ func TestPublicServiceHelm(t *testing.T) {
 			"Values.kube.external_ips":     "[127.0.0.1,127.0.0.2]",
 		}
 
-		actual, err := testhelpers.RoundtripNode(service, config)
+		actual, err := RoundtripNode(service, config)
 		require.NoError(t, err)
 		testhelpers.IsYAMLEqualString(assert, `---
 			apiVersion: "v1"
@@ -394,18 +394,18 @@ func TestActivePassiveService(t *testing.T) {
 				roundTrip := func(node helm.Node) (interface{}, error) {
 					switch variant {
 					case withKube:
-						return testhelpers.RoundtripKube(node)
+						return RoundtripKube(node)
 					case withHelm:
 						config := map[string]interface{}{
 							"Values.kube.external_ips": []string{"192.0.2.42"},
 						}
-						return testhelpers.RoundtripNode(node, config)
+						return RoundtripNode(node, config)
 					case withHelmLoadBalancer:
 						config := map[string]interface{}{
 							"Values.kube.external_ips":     []string{"192.0.2.42"},
 							"Values.services.loadbalanced": "true",
 						}
-						return testhelpers.RoundtripNode(node, config)
+						return RoundtripNode(node, config)
 					}
 					panic("Unexpected variant " + variant)
 				}

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -76,7 +76,7 @@ func TestStatefulSetPorts(t *testing.T) {
 	items = append(items, statefulset)
 	objects := helm.NewMapping("items", helm.NewNode(items))
 
-	actual, err := testhelpers.RoundtripKube(objects)
+	actual, err := RoundtripKube(objects)
 	require.NoError(t, err)
 
 	expected := `---
@@ -198,9 +198,9 @@ func TestStatefulSetServices(t *testing.T) {
 							var err error
 							switch style {
 							case "helm":
-								actual, err = testhelpers.RoundtripNode(headlessService, nil)
+								actual, err = RoundtripNode(headlessService, nil)
 							case "kube":
-								actual, err = testhelpers.RoundtripKube(headlessService)
+								actual, err = RoundtripKube(headlessService)
 							default:
 								panic("Unexpected style " + style)
 							}
@@ -232,9 +232,9 @@ func TestStatefulSetServices(t *testing.T) {
 							var err error
 							switch style {
 							case "helm":
-								actual, err = testhelpers.RoundtripNode(publicService, nil)
+								actual, err = RoundtripNode(publicService, nil)
 							case "kube":
-								actual, err = testhelpers.RoundtripKube(publicService)
+								actual, err = RoundtripKube(publicService)
 							default:
 								panic("Unexpected style " + style)
 							}
@@ -263,9 +263,9 @@ func TestStatefulSetServices(t *testing.T) {
 							var err error
 							switch style {
 							case "helm":
-								actual, err = testhelpers.RoundtripNode(internalService, nil)
+								actual, err = RoundtripNode(internalService, nil)
 							case "kube":
-								actual, err = testhelpers.RoundtripKube(internalService)
+								actual, err = RoundtripKube(internalService)
 							default:
 								panic("Unexpected style " + style)
 							}
@@ -321,7 +321,7 @@ func TestStatefulSetStartupPolicy(t *testing.T) {
 						Opinions: model.NewEmptyOpinions(),
 					}, nil)
 					require.NoError(t, err)
-					actual, err := testhelpers.RoundtripKube(statefulset)
+					actual, err := RoundtripKube(statefulset)
 					require.NoError(t, err)
 					expected := `---
 					spec:
@@ -337,7 +337,7 @@ func TestStatefulSetStartupPolicy(t *testing.T) {
 						CreateHelmChart: true,
 					}, nil)
 					require.NoError(t, err)
-					actual, err := testhelpers.RoundtripNode(statefulset, map[string]interface{}{
+					actual, err := RoundtripNode(statefulset, map[string]interface{}{
 						"Values.sizing.myrole.count":                        "1",
 						"Values.sizing.myrole.capabilities":                 []string{},
 						"Values.sizing.myrole.disk_sizes.persistent_volume": 1,
@@ -370,7 +370,7 @@ func TestStatefulSetVolumesKube(t *testing.T) {
 		return
 	}
 
-	actual, err := testhelpers.RoundtripKube(statefulset)
+	actual, err := RoundtripKube(statefulset)
 	if !assert.NoError(err) {
 		return
 	}
@@ -446,7 +446,7 @@ func TestStatefulSetVolumesWithAnnotationKube(t *testing.T) {
 		return
 	}
 
-	actual, err := testhelpers.RoundtripKube(statefulset)
+	actual, err := RoundtripKube(statefulset)
 	if !assert.NoError(err) {
 		return
 	}
@@ -537,7 +537,7 @@ func TestStatefulSetVolumesHelm(t *testing.T) {
 		"Values.sizing.myrole.disk_sizes.shared_volume":     "40",
 	}
 
-	actual, err := testhelpers.RoundtripNode(statefulset, config)
+	actual, err := RoundtripNode(statefulset, config)
 	if !assert.NoError(err) {
 		return
 	}
@@ -607,7 +607,7 @@ func TestStatefulSetVolumesHelm(t *testing.T) {
 		"Values.sizing.myrole.count":                        "1",
 		"Values.sizing.myrole.disk_sizes.persistent_volume": "5",
 	}
-	actual, err = testhelpers.RoundtripNode(statefulset, overrides)
+	actual, err = RoundtripNode(statefulset, overrides)
 	if !assert.NoError(err) {
 		return
 	}
@@ -633,7 +633,7 @@ func TestStatefulSetEmptyDirVolumesKube(t *testing.T) {
 		return
 	}
 
-	actual, err := testhelpers.RoundtripKube(statefulset)
+	actual, err := RoundtripKube(statefulset)
 	if !assert.NoError(err) {
 		return
 	}

--- a/kube/utils.go
+++ b/kube/utils.go
@@ -51,3 +51,36 @@ func minKubeVersion(major, minor int) string {
 	// We would use `regexFind "[0-9]+"` but that isn't available in helm 2.6.2
 	return fmt.Sprintf(`or (gt (int %s.Major) %d) (and (eq (int %s.Major) %d) (ge (%s.Minor | trimSuffix "+" | int) %d))`, ver, major, ver, major, ver, minor)
 }
+
+// MakeBasicValues returns a Mapping with the default values that do not depend
+// on any configuration.  This is exported so the tests from other packages can
+// access them.
+func MakeBasicValues() *helm.Mapping {
+	return helm.NewMapping(
+		"kube", helm.NewMapping(
+			"external_ips", helm.NewList(),
+			"secrets_generation_counter", helm.NewNode(1, helm.Comment("Increment this counter to rotate all generated secrets")),
+			"storage_class", helm.NewMapping("persistent", "persistent", "shared", "shared"),
+			"hostpath_available", helm.NewNode(false, helm.Comment("Whether HostPath volume mounts are available")),
+			"registry", helm.NewMapping(
+				"hostname", "docker.io",
+				"username", "",
+				"password", ""),
+			"organization", "",
+			"auth", nil),
+		"config", helm.NewMapping(
+			"HA", helm.NewNode(false, helm.Comment("Flag to activate high-availability mode")),
+			"memory", helm.NewNode(helm.NewMapping(
+				"requests", helm.NewNode(false, helm.Comment("Flag to activate memory requests")),
+				"limits", helm.NewNode(false, helm.Comment("Flag to activate memory limits")),
+			), helm.Comment("Global memory configuration")),
+			"cpu", helm.NewNode(helm.NewMapping(
+				"requests", helm.NewNode(false, helm.Comment("Flag to activate cpu requests")),
+				"limits", helm.NewNode(false, helm.Comment("Flag to activate cpu limits")),
+			), helm.Comment("Global CPU configuration"))),
+		"env", helm.NewMapping(),
+		"sizing", helm.NewMapping(),
+		"secrets", helm.NewMapping(),
+		"services", helm.NewMapping(
+			"loadbalanced", false))
+}

--- a/kube/utils_test.go
+++ b/kube/utils_test.go
@@ -17,7 +17,7 @@ func TestNewTypeMeta(t *testing.T) {
 
 	typeMeta := newTypeMeta("the-api-version", "thekind")
 
-	actual, err := testhelpers.RoundtripKube(typeMeta)
+	actual, err := RoundtripKube(typeMeta)
 	if !assert.NoError(err) {
 		return
 	}
@@ -33,7 +33,7 @@ func TestNewObjectMeta(t *testing.T) {
 
 	objectMeta := newObjectMeta("thename")
 
-	actual, err := testhelpers.RoundtripKube(objectMeta)
+	actual, err := RoundtripKube(objectMeta)
 	if !assert.NoError(err) {
 		return
 	}
@@ -50,7 +50,7 @@ func TestNewSelector(t *testing.T) {
 
 	selector := newSelector("thename")
 
-	actual, err := testhelpers.RoundtripKube(selector)
+	actual, err := RoundtripKube(selector)
 	if !assert.NoError(err) {
 		return
 	}
@@ -66,7 +66,7 @@ func TestNewKubeConfig(t *testing.T) {
 
 	kubeConfig := newKubeConfig("theApiVersion", "thekind", "thename")
 
-	actual, err := testhelpers.RoundtripKube(kubeConfig)
+	actual, err := RoundtripKube(kubeConfig)
 	if !assert.NoError(err) {
 		return
 	}
@@ -132,7 +132,7 @@ func TestMinKubeVersion(t *testing.T) {
 			"Capabilities.KubeVersion.Major": testcase.Major,
 			"Capabilities.KubeVersion.Minor": testcase.Minor,
 		}
-		actual, err := testhelpers.RoundtripNode(v, config)
+		actual, err := RoundtripNode(v, config)
 		if !assert.NoError(err) {
 			return
 		}

--- a/kube/values.go
+++ b/kube/values.go
@@ -10,7 +10,7 @@ import (
 
 // MakeValues returns a Mapping with all default values for the Helm chart
 func MakeValues(settings ExportSettings) (helm.Node, error) {
-	values := helm.MakeBasicValues()
+	values := MakeBasicValues()
 	env := helm.NewMapping()
 	secrets := helm.NewMapping()
 	generated := helm.NewMapping()

--- a/kube/values_test.go
+++ b/kube/values_test.go
@@ -41,7 +41,7 @@ func TestMakeValues(t *testing.T) {
 		assert.NotNil(t, node)
 		assert.NoError(t, err)
 
-		actual, err := testhelpers.RoundtripKube(node)
+		actual, err := RoundtripKube(node)
 		if !assert.NoError(t, err) {
 			return
 		}


### PR DESCRIPTION
The helm package is just a specialized templating library; default values for kube specs do not belong there but should be with the related functions in the kube package.

The helm_helper functions are calling `MakeBasicValues()`, so move that file into the kube package as well to avoid circular dependencies (it is also not being used outside the kube package).