### PR TITLE
Fix port collition check problem

### DIFF
--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -1232,8 +1232,28 @@ func TestLoadRoleManifestColocatedContainersValidationPortCollisions(t *testing.
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/model/colocated-containers-with-port-collision.yml")
 	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{torRelease, ntpRelease}, nil)
 	assert.Nil(roleManifest)
-	assert.EqualError(err, "role[main-role]: Invalid value: 80: port collision, the same port is used by: main-role, to-be-colocated\n"+
-		"role[main-role]: Invalid value: 10443: port collision, the same port is used by: main-role, to-be-colocated")
+	assert.EqualError(err, "role[main-role]: Invalid value: \"TCP/10443\": port collision, the same protocol/port is used by: main-role, to-be-colocated"+"\n"+
+		"role[main-role]: Invalid value: \"TCP/80\": port collision, the same protocol/port is used by: main-role, to-be-colocated")
+}
+
+func TestLoadRoleManifestColocatedContainersValidationPortCollisionsWithProtocols(t *testing.T) {
+	assert := assert.New(t)
+
+	workDir, err := os.Getwd()
+	assert.NoError(err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torRelease, err := NewDevRelease(torReleasePath, "", "", filepath.Join(torReleasePath, "bosh-cache"))
+	assert.NoError(err)
+
+	ntpReleasePath := filepath.Join(workDir, "../test-assets/ntp-release")
+	ntpRelease, err := NewDevRelease(ntpReleasePath, "", "", filepath.Join(ntpReleasePath, "bosh-cache"))
+	assert.NoError(err)
+
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/model/colocated-containers-with-no-port-collision.yml")
+	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{torRelease, ntpRelease}, nil)
+	assert.NoError(err)
+	assert.NotNil(roleManifest)
 }
 
 func TestLoadRoleManifestColocatedContainersValidationInvalidTags(t *testing.T) {

--- a/test-assets/role-manifests/model/colocated-containers-with-no-port-collision.yml
+++ b/test-assets/role-manifests/model/colocated-containers-with-no-port-collision.yml
@@ -1,0 +1,39 @@
+---
+roles:
+- name: main-role
+  scripts: ["myrole.sh"]
+  run:
+    memory: 1
+    exposed-ports:
+    - name: http
+      protocol: TCP
+      internal: 8080
+      external: 80
+    - name: https
+      protocol: TCP
+      internal: 9443
+      external: 443
+  tags:
+  - headless
+  jobs:
+  - name: new_hostname
+    release_name: tor
+  - name: tor
+    release_name: tor
+  colocated_containers:
+  - to-be-colocated
+
+- name: to-be-colocated
+  type: colocated-container
+  jobs:
+  - name: ntpd
+    release_name: ntp
+  run:
+    memory: 1
+    exposed-ports:
+    - name: tcp-dbg-port
+      protocol: TCP
+      internal: 10443
+    - name: udp-dbg-port
+      protocol: UDP
+      internal: 10443


### PR DESCRIPTION
Replace lookup logic used in port collision check to use the tuple of
protocol and port (`TCP/53`). That way a port collision is only counted
in case both roles use the same protocol. The same port used by both
protocols is no longer falsely reported as a configuration issue.

This should fix #364.