### PR TITLE
kube: services: use the port number for targetPort definitions

### DIFF
--- a/kube/service.go
+++ b/kube/service.go
@@ -126,7 +126,9 @@ func newService(role *model.InstanceGroup, serviceType newServiceType, settings 
 				if serviceType == newServiceTypeHeadless {
 					newPort.Add("targetPort", 0)
 				} else {
-					newPort.Add("targetPort", portName)
+					// Use number instead of name here, in case we have multiple
+					// port definitions with the same internal port
+					newPort.Add("targetPort", port.InternalPort+portIndex)
 				}
 				ports = append(ports, newPort)
 			}

--- a/kube/service_test.go
+++ b/kube/service_test.go
@@ -64,11 +64,11 @@ func TestServiceKube(t *testing.T) {
 			-
 				name: http
 				port: 80
-				targetPort: http
+				targetPort: 8080
 			-
 				name: https
 				port: 443
-				targetPort: https
+				targetPort: 443
 			selector:
 				skiff-role-name: myrole
 	`, actual)
@@ -108,11 +108,11 @@ func TestServiceHelm(t *testing.T) {
 				-	name: "http"
 					port: 80
 					protocol: "TCP"
-					targetPort: "http"
+					targetPort: 8080
 				-	name: "https"
 					port: 443
 					protocol: "TCP"
-					targetPort: "https"
+					targetPort: 443
 				selector:
 					skiff-role-name: "myrole"
 		`, actual)
@@ -136,11 +136,11 @@ func TestServiceHelm(t *testing.T) {
 				-	name: "http"
 					port: 80
 					protocol: "TCP"
-					targetPort: "http"
+					targetPort: 8080
 				-	name: "https"
 					port: 443
 					protocol: "TCP"
-					targetPort: "https"
+					targetPort: 443
 				selector:
 					skiff-role-name: "myrole"
 		`, actual)
@@ -289,7 +289,7 @@ func TestPublicServiceKube(t *testing.T) {
 			-
 				name: https
 				port: 443
-				targetPort: https
+				targetPort: 443
 			selector:
 				skiff-role-name: myrole
 	`, actual)
@@ -333,7 +333,7 @@ func TestPublicServiceHelm(t *testing.T) {
 				-	name: "https"
 					port: 443
 					protocol: "TCP"
-					targetPort: "https"
+					targetPort: 443
 				selector:
 					skiff-role-name: "myrole"
 		`, actual)
@@ -358,7 +358,7 @@ func TestPublicServiceHelm(t *testing.T) {
 				-	name: "https"
 					port: 443
 					protocol: "TCP"
-					targetPort: "https"
+					targetPort: 443
 				selector:
 					skiff-role-name: "myrole"
 				type:	LoadBalancer
@@ -483,12 +483,12 @@ func TestActivePassiveService(t *testing.T) {
 												name: http
 												port: 80
 												protocol: TCP
-												targetPort: http
+												targetPort: 8080
 											-
 												name: https
 												port: 443
 												protocol: TCP
-												targetPort: https
+												targetPort: 443
 											selector:
 												skiff-role-name: myrole
 												skiff-role-active: "true"
@@ -512,7 +512,7 @@ func TestActivePassiveService(t *testing.T) {
 												name: https
 												port: 443
 												protocol: TCP
-												targetPort: https
+												targetPort: 443
 											selector:
 												skiff-role-name: myrole
 												skiff-role-active: "true"

--- a/kube/stateful_set_test.go
+++ b/kube/stateful_set_test.go
@@ -109,11 +109,11 @@ func TestStatefulSetPorts(t *testing.T) {
 				-
 						name: http
 						port: 80
-						targetPort: http
+						targetPort: 8080
 				-
 						name: https
 						port: 443
-						targetPort: https
+						targetPort: 443
 				selector:
 					skiff-role-name: myrole
 		-
@@ -125,7 +125,7 @@ func TestStatefulSetPorts(t *testing.T) {
 				-
 						name: https
 						port: 443
-						targetPort: https
+						targetPort: 443
 				selector:
 					skiff-role-name: myrole
 		-
@@ -251,7 +251,7 @@ func TestStatefulSetServices(t *testing.T) {
 									name: https
 									port: 443
 									protocol: TCP
-									targetPort: https
+									targetPort: 443
 								selector:
 									skiff-role-name: myrole
 							`, actual)
@@ -281,12 +281,12 @@ func TestStatefulSetServices(t *testing.T) {
 									name: http
 									port: 80
 									protocol: TCP
-									targetPort: http
+									targetPort: 8080
 								-
 									name: https
 									port: 443
 									protocol: TCP
-									targetPort: https
+									targetPort: 443
 								selector:
 									skiff-role-name: myrole
 							`, actual)


### PR DESCRIPTION
When multiple port definitions exist on a pod with the same containerPort (but different external ports), we need to end up using the first one for the service definition as kubernetes has trouble correctly modifying the port definitions on upgrades.  The easiest way to make that work is to just use the numeric port number for the service targetPort, which will end up referring to whichever container port definition that works.