### PR TITLE
Switch to BOSH manifest style variables

### DIFF
--- a/app/fissile.go
+++ b/app/fissile.go
@@ -912,7 +912,7 @@ func (f *Fissile) GenerateKube(roleManifestPath string, defaultFiles []string, s
 
 	cvs := model.MakeMapOfVariables(settings.RoleManifest)
 	for key, value := range cvs {
-		if !value.Secret {
+		if !value.CVOptions.Secret {
 			delete(cvs, key)
 		}
 	}

--- a/kube/pod_test.go
+++ b/kube/pod_test.go
@@ -40,14 +40,15 @@ func podTemplateTestLoadRole(assert *assert.Assertions) *model.InstanceGroup {
 	}
 
 	// Force a broadcast SECRET_VAR into the manifest, to see in all roles
-	manifest.Configuration.Variables =
-		append(manifest.Configuration.Variables,
-			&model.ConfigurationVariable{
-				Name:     "SECRET_VAR",
+	manifest.Variables = append(manifest.Variables,
+		&model.VariableDefinition{
+			Name: "SECRET_VAR",
+			CVOptions: model.CVOptions{
 				Type:     model.CVTypeUser,
 				Secret:   true,
 				Internal: true,
-			})
+			},
+		})
 	return instanceGroup
 }
 
@@ -390,8 +391,8 @@ func TestPodGetEnvVarsFromConfigSizingCountKube(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
 			Name: "KUBE_SIZING_FOO_COUNT",
 		},
 	}, ExportSettings{
@@ -427,8 +428,8 @@ func TestPodGetEnvVarsFromConfigSizingCountHelm(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
 			Name: "KUBE_SIZING_FOO_COUNT",
 		},
 	}, ExportSettings{
@@ -464,11 +465,11 @@ func TestPodGetEnvVarsFromConfigSizingPortsKube(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
 			Name: "KUBE_SIZING_FOO_PORTS_STORE_MIN",
 		},
-		&model.ConfigurationVariable{
+		&model.VariableDefinition{
 			Name: "KUBE_SIZING_FOO_PORTS_STORE_MAX",
 		},
 	}, ExportSettings{
@@ -511,11 +512,11 @@ func TestPodGetEnvVarsFromConfigSizingPortsHelm(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
 			Name: "KUBE_SIZING_FOO_PORTS_STORE_MIN",
 		},
-		&model.ConfigurationVariable{
+		&model.VariableDefinition{
 			Name: "KUBE_SIZING_FOO_PORTS_STORE_MAX",
 		},
 	}, ExportSettings{
@@ -562,8 +563,8 @@ func TestPodGetEnvVarsFromConfigGenerationCounterKube(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
 			Name: "KUBE_SECRETS_GENERATION_COUNTER",
 		},
 	}, ExportSettings{
@@ -594,8 +595,8 @@ func TestPodGetEnvVarsFromConfigGenerationCounterHelm(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
 			Name: "KUBE_SECRETS_GENERATION_COUNTER",
 		},
 	}, ExportSettings{
@@ -631,8 +632,8 @@ func TestPodGetEnvVarsFromConfigGenerationNameKube(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
 			Name: "KUBE_SECRETS_GENERATION_NAME",
 		},
 	}, ExportSettings{
@@ -663,8 +664,8 @@ func TestPodGetEnvVarsFromConfigGenerationNameHelm(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
 			Name: "KUBE_SECRETS_GENERATION_NAME",
 		},
 	}, ExportSettings{
@@ -700,10 +701,12 @@ func TestPodGetEnvVarsFromConfigGenerationNameHelm(t *testing.T) {
 func TestPodGetEnvVarsFromConfigSecretsKube(t *testing.T) {
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
-			Name:   "A_SECRET",
-			Secret: true,
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
+			Name: "A_SECRET",
+			CVOptions: model.CVOptions{
+				Secret: true,
+			},
 		},
 	}, ExportSettings{
 		RoleManifest: &model.RoleManifest{
@@ -749,10 +752,12 @@ func TestPodGetEnvVarsFromConfigSecretsHelm(t *testing.T) {
 
 	t.Run("Plain", func(t *testing.T) {
 		t.Parallel()
-		ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-			&model.ConfigurationVariable{
-				Name:   "A_SECRET",
-				Secret: true,
+		ev, err := getEnvVarsFromConfigs(model.Variables{
+			&model.VariableDefinition{
+				Name: "A_SECRET",
+				CVOptions: model.CVOptions{
+					Secret: true,
+				},
 			},
 		}, settings)
 		if !assert.NoError(err) {
@@ -779,14 +784,12 @@ func TestPodGetEnvVarsFromConfigSecretsHelm(t *testing.T) {
 
 	t.Run("Generated", func(t *testing.T) {
 		t.Parallel()
-		cv := []*model.ConfigurationVariable{
-			&model.ConfigurationVariable{
-				Name:   "A_SECRET",
-				Secret: true,
-				Generator: &model.ConfigurationVariableGenerator{
-					ID:        "no",
-					Type:      model.GeneratorTypePassword,
-					ValueType: "foo-login",
+		cv := model.Variables{
+			&model.VariableDefinition{
+				Name: "A_SECRET",
+				Type: "password",
+				CVOptions: model.CVOptions{
+					Secret: true,
 				},
 			},
 		}
@@ -846,7 +849,7 @@ func TestPodGetEnvVarsFromConfigSecretsHelm(t *testing.T) {
 			`, actual)
 		})
 
-		cv[0].Immutable = true
+		cv[0].CVOptions.Immutable = true
 		ev, err = getEnvVarsFromConfigs(cv, settings)
 		if !assert.NoError(err) {
 			return
@@ -888,10 +891,12 @@ func TestPodGetEnvVarsFromConfigNonSecretKube(t *testing.T) {
 
 	t.Run("Present", func(t *testing.T) {
 		t.Parallel()
-		ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-			&model.ConfigurationVariable{
-				Name:    "SOMETHING",
-				Default: []string{"or", "other"},
+		ev, err := getEnvVarsFromConfigs(model.Variables{
+			&model.VariableDefinition{
+				Name: "SOMETHING",
+				CVOptions: model.CVOptions{
+					Default: []string{"or", "other"},
+				},
 			},
 		}, settings)
 
@@ -912,8 +917,8 @@ func TestPodGetEnvVarsFromConfigNonSecretKube(t *testing.T) {
 
 	t.Run("Missing", func(t *testing.T) {
 		t.Parallel()
-		ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-			&model.ConfigurationVariable{
+		ev, err := getEnvVarsFromConfigs(model.Variables{
+			&model.VariableDefinition{
 				Name: "SOMETHING",
 			},
 		}, settings)
@@ -935,10 +940,12 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserOptional(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
 			Name: "SOMETHING",
-			Type: model.CVTypeUser,
+			CVOptions: model.CVOptions{
+				Type: model.CVTypeUser,
+			},
 		},
 	}, ExportSettings{
 		CreateHelmChart: true,
@@ -1000,11 +1007,13 @@ func TestPodGetEnvVarsFromConfigNonSecretHelmUserRequired(t *testing.T) {
 	t.Parallel()
 	assert := assert.New(t)
 
-	ev, err := getEnvVarsFromConfigs([]*model.ConfigurationVariable{
-		&model.ConfigurationVariable{
-			Name:     "SOMETHING",
-			Type:     model.CVTypeUser,
-			Required: true,
+	ev, err := getEnvVarsFromConfigs(model.Variables{
+		&model.VariableDefinition{
+			Name: "SOMETHING",
+			CVOptions: model.CVOptions{
+				Type:     model.CVTypeUser,
+				Required: true,
+			},
 		},
 	}, ExportSettings{
 		CreateHelmChart: true,

--- a/kube/secret.go
+++ b/kube/secret.go
@@ -18,16 +18,16 @@ func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, error
 	for name, cv := range secrets {
 		key := util.ConvertNameToKey(name)
 		var value interface{}
-		comment := cv.Description
+		comment := cv.CVOptions.Description
 
 		if settings.CreateHelmChart {
-			if cv.Generator == nil {
-				if cv.Immutable {
+			if cv.Type == "" {
+				if cv.CVOptions.Immutable {
 					comment += "\nThis value is immutable and must not be changed once set."
 				}
-				comment += formattedExample(cv.Example, value)
+				comment += formattedExample(cv.CVOptions.Example, value)
 				required := `{{"" | b64enc | quote}}`
-				if cv.Required {
+				if cv.CVOptions.Required {
 					required = fmt.Sprintf(`{{fail "secrets.%s has not been set"}}`, cv.Name)
 				}
 				name := ".Values.secrets." + cv.Name
@@ -35,8 +35,8 @@ func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, error
 					`{{%s | toJson | b64enc | quote}}{{else}}{{%s | b64enc | quote}}{{end}}{{else}}%s{{end}}`
 				value = fmt.Sprintf(tmpl, name, name, name, name, required)
 				data.Add(key, helm.NewNode(value, helm.Comment(comment)))
-			} else if !cv.Immutable {
-				comment += formattedExample(cv.Example, value)
+			} else if !cv.CVOptions.Immutable {
+				comment += formattedExample(cv.CVOptions.Example, value)
 				comment += "\nThis value uses a generated default."
 				value = fmt.Sprintf(`{{ default "" .Values.secrets.%s | b64enc | quote }}`, cv.Name)
 				generated.Add(key, helm.NewNode(value, helm.Comment(comment)))
@@ -48,7 +48,7 @@ func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, error
 				value = ""
 			}
 			value = base64.StdEncoding.EncodeToString([]byte(value))
-			comment += formattedExample(cv.Example, value)
+			comment += formattedExample(cv.CVOptions.Example, value)
 			data.Add(key, helm.NewNode(value, helm.Comment(comment)))
 		}
 	}

--- a/kube/secret_test.go
+++ b/kube/secret_test.go
@@ -63,56 +63,62 @@ func TestMakeSecretsEmpty(t *testing.T) {
 
 func testCVMap() model.CVMap {
 	return model.CVMap{
-		"optional": &model.ConfigurationVariable{
-			// This variable is only defined to verify that missing non-required secrets won't throw any errors
-			Name:     "optional",
-			Required: false,
-			Default:  nil,
-		},
-		"min": &model.ConfigurationVariable{
-			Name: "min",
-		},
-		"desc": &model.ConfigurationVariable{
-			Name:        "desc",
-			Description: "<<<a description>>>",
-			Example:     "Use this",
-		},
-		"valued": &model.ConfigurationVariable{
-			Name:        "valued",
-			Description: "<<<invaluable>>>",
-			Default:     "you are very valued indeed",
-		},
-		"structured": &model.ConfigurationVariable{
-			Name:        "structured",
-			Description: "<<<non-scalar>>>",
-			Example:     "use: \"this\"\n",
-			Default:     map[string]string{"non": "scalar"},
-		},
-		"const": &model.ConfigurationVariable{
-			Name:        "const",
-			Description: "<<<don't change>>>",
-			Default:     "rock solid",
-			Required:    true,
-			Immutable:   true,
-		},
-		"genie": &model.ConfigurationVariable{
-			Name:        "genie",
-			Description: "<<<here is jeannie>>>",
-			Generator: &model.ConfigurationVariableGenerator{
-				ID:        "xxx",
-				Type:      model.GeneratorTypePassword,
-				ValueType: "snafu",
+		"optional": &model.VariableDefinition{
+			Name: "optional",
+			CVOptions: model.CVOptions{
+				// This variable is only defined to verify that missing non-required secrets won't throw any errors
+				Required: false,
+				Default:  nil,
 			},
 		},
-		"guinevere": &model.ConfigurationVariable{
+		"min": &model.VariableDefinition{
+			Name: "min",
+		},
+		"desc": &model.VariableDefinition{
+			Name: "desc",
+			CVOptions: model.CVOptions{
+				Description: "<<<a description>>>",
+				Example:     "Use this",
+			},
+		},
+		"valued": &model.VariableDefinition{
+			Name: "valued",
+			CVOptions: model.CVOptions{
+				Description: "<<<invaluable>>>",
+				Default:     "you are very valued indeed",
+			},
+		},
+		"structured": &model.VariableDefinition{
+			Name: "structured",
+			CVOptions: model.CVOptions{
+				Description: "<<<non-scalar>>>",
+				Example:     "use: \"this\"\n",
+				Default:     map[string]string{"non": "scalar"},
+			},
+		},
+		"const": &model.VariableDefinition{
+			Name: "const",
+			CVOptions: model.CVOptions{
+				Description: "<<<don't change>>>",
+				Default:     "rock solid",
+				Required:    true,
+				Immutable:   true,
+			},
+		},
+		"genie": &model.VariableDefinition{
+			Name: "genie",
+			Type: "password",
+			CVOptions: model.CVOptions{
+				Description: "<<<here is jeannie>>>",
+			},
+		},
+		"guinevere": &model.VariableDefinition{
 			// excluded from __helm__ output
-			Name:        "guinevere",
-			Description: "<<<helm hidden>>>",
-			Immutable:   true,
-			Generator: &model.ConfigurationVariableGenerator{
-				ID:        "xxx",
-				Type:      model.GeneratorTypePassword,
-				ValueType: "snafu",
+			Name: "guinevere",
+			Type: "password",
+			CVOptions: model.CVOptions{
+				Description: "<<<helm hidden>>>",
+				Immutable:   true,
 			},
 		},
 	}
@@ -134,10 +140,10 @@ func TestMakeSecretsKube(t *testing.T) {
 		return
 	}
 
-	varStructuredJSON, _ := json.Marshal(testCV["structured"].Default)
+	varStructuredJSON, _ := json.Marshal(testCV["structured"].CVOptions.Default)
 
-	varConstB64 := RenderEncodeBase64(testCV["const"].Default.(string))
-	varValuedB64 := RenderEncodeBase64(testCV["valued"].Default.(string))
+	varConstB64 := RenderEncodeBase64(testCV["const"].CVOptions.Default.(string))
+	varValuedB64 := RenderEncodeBase64(testCV["valued"].CVOptions.Default.(string))
 	varStructuredB64 := RenderEncodeBase64(string(varStructuredJSON))
 
 	// Check the comments, and also that they are associated with

--- a/model/configuration.go
+++ b/model/configuration.go
@@ -1,0 +1,26 @@
+package model
+
+// Configuration contains information about how to configure the
+// resulting images
+type Configuration struct {
+	Authorization struct {
+		Roles    map[string]AuthRole    `yaml:"roles,omitempty"`
+		Accounts map[string]AuthAccount `yaml:"accounts,omitempty"`
+	} `yaml:"auth,omitempty"`
+	Templates map[string]string `yaml:"templates"`
+}
+
+// An AuthRule is a single rule for a RBAC authorization role
+type AuthRule struct {
+	APIGroups []string `yaml:"apiGroups"`
+	Resources []string `yaml:"resources"`
+	Verbs     []string `yaml:"verbs"`
+}
+
+// An AuthRole is a role for RBAC authorization
+type AuthRole []AuthRule
+
+// An AuthAccount is a service account for RBAC authorization
+type AuthAccount struct {
+	Roles []string `yaml:"roles"`
+}

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -442,7 +442,8 @@ func TestLoadRoleManifestBadCVType(t *testing.T) {
 
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/model/bad-cv-type.yml")
 	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
-	assert.EqualError(t, err,
+
+	require.EqualError(t, err,
 		`configuration.variables[BAR].type: Invalid value: "bogus": Expected one of user, or environment`)
 	assert.Nil(t, roleManifest)
 }

--- a/model/variables.go
+++ b/model/variables.go
@@ -1,0 +1,117 @@
+package model
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Variables from the BOSH manifests variables section
+type Variables []*VariableDefinition
+
+// VariableDefinition from the BOSH deployment manifest
+// Type is used to decide on a generator
+type VariableDefinition struct {
+	Name      string
+	Type      string
+	Options   VariableOptions
+	CVOptions CVOptions
+}
+
+// VariableOptions are not structured, their content depends on the type
+type VariableOptions map[string]interface{}
+
+// CVOptions is a configuration to be exposed to the IaaS
+//
+// Notes on the fields Type and Internal.
+// 1. Type's legal values are `user` and `environment`.
+//    `user` is default.
+//
+//    A `user` CV is rendered into k8s yml config files, etc. to make it available to roles who need it.
+//    - An internal CV is rendered to all roles.
+//    - A public CV is rendered only to the roles whose templates refer to the CV.
+//
+//    An `environment` CV comes from a script, not the user. Being
+//    internal this way it is not rendered to any configuration files.
+//
+// 2. Internal's legal values are all YAML boolean values.
+//    A public CV is used in templates
+//    An internal CV is not, consumed in a script instead.
+type CVOptions struct {
+	PreviousNames []string    `yaml:"previous_names"`
+	Default       interface{} `yaml:"default"`
+	Description   string      `yaml:"description"`
+	Example       string      `yaml:"example"`
+	Type          CVType      `yaml:"type"`
+	Internal      bool        `yaml:"internal,omitempty"`
+	Secret        bool        `yaml:"secret,omitempty"`
+	Required      bool        `yaml:"required,omitempty"`
+	Immutable     bool        `yaml:"immutable,omitempty"`
+}
+
+// CVType is the type of the configuration variable; see the constants below
+type CVType string
+
+const (
+	// CVTypeUser is for user-specified variables (default)
+	CVTypeUser = CVType("user")
+	// CVTypeEnv is for script-specified variables
+	CVTypeEnv = CVType("environment")
+)
+
+// CVMap is a map from variable name to ConfigurationVariable, for
+// various places which require quick access/search/existence check.
+type CVMap map[string]*VariableDefinition
+
+type internalVariable struct {
+	CVOptions CVOptions `yaml:"options"`
+}
+
+type internalVariableDefinitions struct {
+	Variables []internalVariable `yaml:"variables"`
+}
+
+// Value fetches the value of config variable
+func (config *VariableDefinition) Value(defaults map[string]string) (bool, string) {
+	var value interface{}
+
+	value = config.CVOptions.Default
+
+	if defaultValue, ok := defaults[config.Name]; ok {
+		value = defaultValue
+	}
+
+	if value == nil {
+		return false, ""
+	}
+
+	var stringifiedValue string
+	if valueAsString, ok := value.(string); ok {
+		var err error
+		stringifiedValue, err = strconv.Unquote(fmt.Sprintf(`"%s"`, valueAsString))
+		if err != nil {
+			stringifiedValue = valueAsString
+		}
+	} else {
+		asJSON, _ := json.Marshal(value)
+		stringifiedValue = string(asJSON)
+	}
+
+	return true, stringifiedValue
+}
+
+// Len is the number of ConfigurationVariables in the slice
+func (confVars Variables) Len() int {
+	return len(confVars)
+}
+
+// Less reports whether config variable at index i sort before the one at index j
+func (confVars Variables) Less(i, j int) bool {
+	return strings.Compare(confVars[i].Name, confVars[j].Name) < 0
+}
+
+// Swap exchanges configuration variables at index i and index j
+func (confVars Variables) Swap(i, j int) {
+	confVars[i], confVars[j] = confVars[j], confVars[i]
+}

--- a/model/variables_test.go
+++ b/model/variables_test.go
@@ -1,0 +1,29 @@
+package model
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadDeploymentManifestVariables(t *testing.T) {
+	workDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(t, err)
+
+	roleManifestPath := filepath.Join(workDir, "../test-assets/deployment-manifests/bosh-deployment.yml")
+	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
+	assert.NoError(t, err)
+	require.NotNil(t, roleManifest)
+
+	assert.Len(t, roleManifest.Variables, 2)
+	assert.Equal(t, "admin_password", roleManifest.Variables[0].Name)
+	assert.Equal(t, true, roleManifest.Variables[1].CVOptions.Secret)
+}

--- a/test-assets/deployment-manifests/bosh-deployment.yml
+++ b/test-assets/deployment-manifests/bosh-deployment.yml
@@ -1,0 +1,21 @@
+---
+instance_groups:
+- name: myrole
+  run:
+    foo: x
+  jobs:
+  - name: tor
+    release: tor
+
+variables:
+- name: admin_password
+  type: password
+  options:
+    internal: true
+- name: default_ca
+  type: certificate
+  options:
+    secret: true
+    is_ca: true
+    common_name: ca
+    internal: true

--- a/test-assets/role-manifests/app/hashmat.yml
+++ b/test-assets/role-manifests/app/hashmat.yml
@@ -8,9 +8,9 @@ instance_groups:
   - name: hashmat
     release: tor
 configuration:
-  variables:
-  - name: FOO
   templates:
     properties.is.a.hash.foo: '((FOO)) extend hash, ok'
     properties.its.a.hash.foo: '((FOO)) extend possible hash, ok'
     properties.not.a.hash.foo: '((FOO)) extend a non-hash, fail'
+variables:
+- name: FOO

--- a/test-assets/role-manifests/app/tor-validation-issues.yml
+++ b/test-assets/role-manifests/app/tor-validation-issues.yml
@@ -20,13 +20,13 @@ instance_groups:
   - name: tor
     release: tor
 configuration:
-  variables:
-  - name: BAR
-  - name: FOO
-  - name: HOME
-  - name: PELERINUL
   templates:
     properties.tor.hostname: '((FOO))'
     properties.tor.private_key: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
     properties.fox: '((FOO): Not specified in any release'
+variables:
+- name: BAR
+- name: FOO
+- name: HOME
+- name: PELERINUL

--- a/test-assets/role-manifests/app/tor-validation-ok.yml
+++ b/test-assets/role-manifests/app/tor-validation-ok.yml
@@ -26,14 +26,15 @@ instance_groups:
   - name: tor
     release: tor
 configuration:
-  variables:
-  - name: BAR
-  - name: FOO
-  - name: HOME
-  - name: KUPRIES
-    internal: true
-  - name: PELERINUL
   templates:
     properties.tor.hostname: '((FOO))'
     properties.tor.private_key: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
+variables:
+- name: BAR
+- name: FOO
+- name: HOME
+- name: KUPRIES
+  options:
+    internal: true
+- name: PELERINUL

--- a/test-assets/role-manifests/builder/tor-good.yml
+++ b/test-assets/role-manifests/builder/tor-good.yml
@@ -25,12 +25,12 @@ instance_groups:
   - name: tor
     release: tor
 configuration:
-  variables:
-  - name: BAR
-  - name: FOO
-  - name: HOME
-  - name: PELERINUL
   templates:
     properties.tor.hostname: '((FOO))'
     properties.tor.private_key.thing: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
+variables:
+- name: BAR
+- name: FOO
+- name: HOME
+- name: PELERINUL

--- a/test-assets/role-manifests/kube/colocated-containers-with-stateful-set-and-empty-dir.yml
+++ b/test-assets/role-manifests/kube/colocated-containers-with-stateful-set-and-empty-dir.yml
@@ -43,7 +43,8 @@ instance_groups:
 configuration:
   templates:
     fox: ((SOME_VAR))
-  variables:
-  - name: ALL_VAR
+variables:
+- name: ALL_VAR
+  options:
     internal: true
-  - name: SOME_VAR
+- name: SOME_VAR

--- a/test-assets/role-manifests/kube/volumes.yml
+++ b/test-assets/role-manifests/kube/volumes.yml
@@ -25,7 +25,8 @@ instance_groups:
 configuration:
   templates:
     fox: ((SOME_VAR))
-  variables:
-  - name: ALL_VAR
+variables:
+- name: ALL_VAR
+  options:
     internal: true
-  - name: SOME_VAR
+- name: SOME_VAR

--- a/test-assets/role-manifests/model/bad-cv-type-internal.yml
+++ b/test-assets/role-manifests/model/bad-cv-type-internal.yml
@@ -8,9 +8,10 @@ instance_groups:
   - name: new_hostname
     release: tor
 configuration:
-  variables:
-  - name: BAR
-    type: environment
-    internal: true
   templates:
     properties.tor.hostname: '((BAR))'
+variables:
+- name: BAR
+  options:
+    type: environment
+    internal: true

--- a/test-assets/role-manifests/model/bad-cv-type.yml
+++ b/test-assets/role-manifests/model/bad-cv-type.yml
@@ -26,13 +26,14 @@ instance_groups:
   - name: tor
     release: tor
 configuration:
-  variables:
-  - name: BAR
-    type: bogus
-  - name: FOO
-  - name: HOME
-  - name: PELERINUL
   templates:
     properties.tor.hostname: '((FOO))'
     properties.tor.private_key.thing: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
+variables:
+- name: BAR
+  options:
+    type: bogus
+- name: FOO
+- name: HOME
+- name: PELERINUL

--- a/test-assets/role-manifests/model/bosh-run-missing.yml
+++ b/test-assets/role-manifests/model/bosh-run-missing.yml
@@ -14,12 +14,12 @@ instance_groups:
   - name: tor
     release: tor
 configuration:
-  variables:
-  - name: BAR
-  - name: FOO
-  - name: HOME
-  - name: PELERINUL
   templates:
     properties.tor.hostname: '((FOO))'
     properties.tor.private_key: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
+variables:
+- name: BAR
+- name: FOO
+- name: HOME
+- name: PELERINUL

--- a/test-assets/role-manifests/model/templates-non.yml
+++ b/test-assets/role-manifests/model/templates-non.yml
@@ -25,11 +25,11 @@ instance_groups:
   - name: tor
     release: tor
 configuration:
-  variables:
-  - name: BAR
-  - name: HOME
-  - name: PELERINUL
   templates:
     properties.tor.hostname: ''
     properties.tor.private_key: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
+variables:
+- name: BAR
+- name: HOME
+- name: PELERINUL

--- a/test-assets/role-manifests/model/variable-expansion.yml
+++ b/test-assets/role-manifests/model/variable-expansion.yml
@@ -9,12 +9,12 @@ instance_groups:
   - name: tor
     release: tor
 configuration:
-  variables:
-  - name: BAR
-  - name: FOO
-  - name: HOME
-  - name: PELERINUL
   templates:
     properties.tor.hostname: '((FOO))'
     properties.tor.private_key.thing: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
+variables:
+  - name: BAR
+  - name: FOO
+  - name: HOME
+  - name: PELERINUL

--- a/test-assets/role-manifests/model/variables-badly-sorted.yml
+++ b/test-assets/role-manifests/model/variables-badly-sorted.yml
@@ -1,13 +1,13 @@
 # This role manifest tests that badly sorted variables are an error
 ---
 configuration:
-  variables:
-  - name: FOO
-  - name: BAR
-  - name: PELERINUL
-  - name: PELERINUL
-  - name: ALPHA
   templates:
     properties.tor.hostname: '((FOO))((ALPHA))'
     properties.tor.private_key: '((#BAR))((HOME))((/BAR))'
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
+variables:
+- name: FOO
+- name: BAR
+- name: PELERINUL
+- name: PELERINUL
+- name: ALPHA

--- a/test-assets/role-manifests/model/variables-with-dup-prev-names.yml
+++ b/test-assets/role-manifests/model/variables-with-dup-prev-names.yml
@@ -1,11 +1,13 @@
 # This role manifest tests that multiple variables with the same previous_name is an error
 ---
 configuration:
-  variables:
-  - name: BAR
-  - name: FOO
-    previous_names: [BAR, BAZ]
-  - name: QUX
-    previous_names: [BAZ]
   templates:
     properties.tor.hostname: '((FOO))((BAR))((QUX))'
+variables:
+- name: BAR
+- name: FOO
+  options:
+    previous_names: [BAR, BAZ]
+- name: QUX
+  options:
+    previous_names: [BAZ]

--- a/test-assets/role-manifests/model/variables-without-decl.yml
+++ b/test-assets/role-manifests/model/variables-without-decl.yml
@@ -8,11 +8,11 @@ instance_groups:
   - name: tor
     release: tor
 configuration:
-  variables:
-  - name: BAR
-  - name: FOO
-  - name: PELERINUL
   templates:
     properties.tor.hostname: '((FOO))'
     properties.tor.private_key: '((#BAR))((HOME))((/BAR))' # HOME is not declared
     properties.tor.hashed_control_password: '((={{ }}=)){{PELERINUL}}'
+variables:
+- name: BAR
+- name: FOO
+- name: PELERINUL

--- a/test-assets/role-manifests/model/variables-without-usage.yml
+++ b/test-assets/role-manifests/model/variables-without-usage.yml
@@ -6,6 +6,5 @@ instance_groups:
   - name: tor
     release: tor
   run: {}
-configuration:
-  variables:
+variables:
   - name: SOME_VAR # Unused


### PR DESCRIPTION
Implements BOSH variables section for https://github.com/SUSE/fissile/issues/370

This relies on https://github.com/SUSE/scf-secret-generator/pull/30

* removed Generator
* SSL private keys and SSH fingerprints no longer have a separate entry,
* all variable options are now below options
* containerization specific variables are also below options
* variables have a type instead of a Generator
* in contrast to BOSH empty type is supported for role manifest
* subject_names is now alternative_names

https://www.pivotaltracker.com/story/show/160013630
