### PR TITLE
mm/fix dependent variables

### DIFF
--- a/docs/validator-description.md
+++ b/docs/validator-description.md
@@ -152,22 +152,22 @@ release__, about excluded properties applies here as well too.
 ### All vars in env files must exist in the role manifest
 
 All variables found in the `.env` files given to the validator must
-exists under the key `configuration.variables` in the role manifest.
+exists under the key `variables` in the role manifest.
 
 ### All role manifest parameters must be sorted
 
-Check that all parameters declared under `configuration.variables` are
+Check that all parameters declared under `variables` are
 listed in lexicographical order.
 
 ### All role manifest parameters must be used
 
-The elements under key `configuration.variables` in the role manifest are also
+The elements under key `variables` in the role manifest are also
 called __parameters__.
 
 Go over the properties, process the mustache templates, extract the
 parameters used in them. Calls this the set `TP`.
 
-Check that all parameters declared under `configuration.variables`
+Check that all parameters declared under `variables`
 (the set `CV`) are used by at least one template. I.e. `CV - TP`
 should be empty.
 
@@ -176,7 +176,7 @@ should be empty.
 This check is complementary to __All role manifest parameters must be used__.
 
 Go over the parameters found in the mustache templates and check they
-they exist under `configuration.variables`. Using the definitions for
+they exist under `variables`. Using the definitions for
 `TP` and `CV` from the previous section, the set `TP - CV` should be
 empty.
 

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -493,10 +493,6 @@ func getEnvVarsFromConfigs(configs model.Variables, settings ExportSettings) (he
 	return helm.NewNode(env), nil
 }
 
-func independentSecret(name string) bool {
-	return !strings.HasSuffix(name, "_KEY") && !strings.HasSuffix(name, "_FINGERPRINT")
-}
-
 func getSecurityContext(role *model.InstanceGroup, createHelmChart bool) helm.Node {
 	var hasAll string
 	var notAll string

--- a/kube/pod.go
+++ b/kube/pod.go
@@ -445,7 +445,7 @@ func getEnvVarsFromConfigs(configs model.Variables, settings ExportSettings) (he
 				if config.CVOptions.Immutable && config.Type != "" {
 					// Users cannot override immutable secrets that are generated
 					env = append(env, makeSecretVar(config.Name, true))
-				} else if config.Type == "" {
+				} else if config.Type == "" && independentSecret(config.Name) {
 					env = append(env, makeSecretVar(config.Name, false))
 				} else {
 					// Generated secrets can be overridden by the user (unless immutable)
@@ -491,6 +491,10 @@ func getEnvVarsFromConfigs(configs model.Variables, settings ExportSettings) (he
 		return env[i].Get("name").String() < env[j].Get("name").String()
 	})
 	return helm.NewNode(env), nil
+}
+
+func independentSecret(name string) bool {
+	return !strings.HasSuffix(name, "_KEY") && !strings.HasSuffix(name, "_FINGERPRINT")
 }
 
 func getSecurityContext(role *model.InstanceGroup, createHelmChart bool) helm.Node {

--- a/kube/secret.go
+++ b/kube/secret.go
@@ -21,6 +21,7 @@ func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, error
 		comment := cv.CVOptions.Description
 
 		if settings.CreateHelmChart {
+			// cv.Generator == nil
 			if cv.Type == "" {
 				if cv.CVOptions.Immutable {
 					comment += "\nThis value is immutable and must not be changed once set."

--- a/kube/secret.go
+++ b/kube/secret.go
@@ -3,6 +3,7 @@ package kube
 import (
 	"encoding/base64"
 	"fmt"
+	"strings"
 
 	"github.com/SUSE/fissile/helm"
 	"github.com/SUSE/fissile/model"
@@ -22,7 +23,7 @@ func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, error
 
 		if settings.CreateHelmChart {
 			// cv.Generator == nil
-			if cv.Type == "" {
+			if cv.Type == "" && independentSecret(cv.Name) {
 				if cv.CVOptions.Immutable {
 					comment += "\nThis value is immutable and must not be changed once set."
 				}
@@ -60,4 +61,8 @@ func MakeSecrets(secrets model.CVMap, settings ExportSettings) (helm.Node, error
 	secret.Add("data", data)
 
 	return secret.Sort(), nil
+}
+
+func independentSecret(name string) bool {
+	return !strings.HasSuffix(name, "_KEY") && !strings.HasSuffix(name, "_FINGERPRINT")
 }

--- a/model/roles.go
+++ b/model/roles.go
@@ -476,12 +476,12 @@ func validateVariableType(variables Variables) validation.ErrorList {
 		case CVTypeEnv:
 			if cv.CVOptions.Internal {
 				allErrs = append(allErrs, validation.Invalid(
-					fmt.Sprintf("configuration.variables[%s].type", cv.Name),
+					fmt.Sprintf("variables[%s].type", cv.Name),
 					cv.CVOptions.Type, `type conflicts with flag "internal"`))
 			}
 		default:
 			allErrs = append(allErrs, validation.Invalid(
-				fmt.Sprintf("configuration.variables[%s].type", cv.Name),
+				fmt.Sprintf("variables[%s].type", cv.Name),
 				cv.CVOptions.Type, "Expected one of user, or environment"))
 		}
 	}
@@ -497,11 +497,11 @@ func validateVariableSorting(variables Variables) validation.ErrorList {
 	previousName := ""
 	for _, cv := range variables {
 		if cv.Name < previousName {
-			allErrs = append(allErrs, validation.Invalid("configuration.variables",
+			allErrs = append(allErrs, validation.Invalid("variables",
 				previousName,
 				fmt.Sprintf("Does not sort before '%s'", cv.Name)))
 		} else if cv.Name == previousName {
-			allErrs = append(allErrs, validation.Invalid("configuration.variables",
+			allErrs = append(allErrs, validation.Invalid("variables",
 				previousName, "Appears more than once"))
 		}
 		previousName = cv.Name
@@ -519,13 +519,13 @@ func validateVariablePreviousNames(variables Variables) validation.ErrorList {
 		for _, previousOuter := range cvOuter.CVOptions.PreviousNames {
 			for _, cvInner := range variables {
 				if previousOuter == cvInner.Name {
-					allErrs = append(allErrs, validation.Invalid("configuration.variables",
+					allErrs = append(allErrs, validation.Invalid("variables",
 						cvOuter.Name,
 						fmt.Sprintf("Previous name '%s' also exist as a new variable", cvInner.Name)))
 				}
 				for _, previousInner := range cvInner.CVOptions.PreviousNames {
 					if cvOuter.Name != cvInner.Name && previousOuter == previousInner {
-						allErrs = append(allErrs, validation.Invalid("configuration.variables",
+						allErrs = append(allErrs, validation.Invalid("variables",
 							cvOuter.Name,
 							fmt.Sprintf("Previous name '%s' also claimed by '%s'", previousOuter, cvInner.Name)))
 					}
@@ -614,8 +614,8 @@ func validateVariableUsage(roleManifest *RoleManifest) validation.ErrorList {
 			continue
 		}
 
-		allErrs = append(allErrs, validation.NotFound(cv,
-			"Not used in any template"))
+		allErrs = append(allErrs, validation.NotFound("variables",
+			fmt.Sprintf("No templates using '%s'", cv)))
 	}
 
 	return allErrs
@@ -653,7 +653,7 @@ func validateTemplateUsage(roleManifest *RoleManifest) validation.ErrorList {
 							continue
 						}
 
-						allErrs = append(allErrs, validation.NotFound("configuration.variables",
+						allErrs = append(allErrs, validation.NotFound("variables",
 							fmt.Sprintf("No declaration of '%s'", envVar)))
 
 						// Add a placeholder so that this variable is not reported again.

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -361,9 +361,9 @@ func TestLoadRoleManifestVariablesSortedError(t *testing.T) {
 	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
 	require.Error(t, err)
 
-	assert.Contains(t, err.Error(), `configuration.variables: Invalid value: "FOO": Does not sort before 'BAR'`)
-	assert.Contains(t, err.Error(), `configuration.variables: Invalid value: "PELERINUL": Does not sort before 'ALPHA'`)
-	assert.Contains(t, err.Error(), `configuration.variables: Invalid value: "PELERINUL": Appears more than once`)
+	assert.Contains(t, err.Error(), `variables: Invalid value: "FOO": Does not sort before 'BAR'`)
+	assert.Contains(t, err.Error(), `variables: Invalid value: "PELERINUL": Does not sort before 'ALPHA'`)
+	assert.Contains(t, err.Error(), `variables: Invalid value: "PELERINUL": Appears more than once`)
 	// Note how this ignores other errors possibly present in the manifest and releases.
 	assert.Nil(t, roleManifest)
 }
@@ -381,9 +381,9 @@ func TestLoadRoleManifestVariablesPreviousNamesError(t *testing.T) {
 	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
 	require.Error(t, err)
 
-	assert.Contains(t, err.Error(), `configuration.variables: Invalid value: "FOO": Previous name 'BAR' also exist as a new variable`)
-	assert.Contains(t, err.Error(), `configuration.variables: Invalid value: "FOO": Previous name 'BAZ' also claimed by 'QUX'`)
-	assert.Contains(t, err.Error(), `configuration.variables: Invalid value: "QUX": Previous name 'BAZ' also claimed by 'FOO'`)
+	assert.Contains(t, err.Error(), `variables: Invalid value: "FOO": Previous name 'BAR' also exist as a new variable`)
+	assert.Contains(t, err.Error(), `variables: Invalid value: "FOO": Previous name 'BAZ' also claimed by 'QUX'`)
+	assert.Contains(t, err.Error(), `variables: Invalid value: "QUX": Previous name 'BAZ' also claimed by 'FOO'`)
 	// Note how this ignores other errors possibly present in the manifest and releases.
 	assert.Nil(t, roleManifest)
 }
@@ -400,7 +400,7 @@ func TestLoadRoleManifestVariablesNotUsed(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/model/variables-without-usage.yml")
 	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
 	assert.EqualError(t, err,
-		`SOME_VAR: Not found: "Not used in any template"`)
+		`variables: Not found: "No templates using 'SOME_VAR'"`)
 	assert.Nil(t, roleManifest)
 }
 
@@ -416,7 +416,7 @@ func TestLoadRoleManifestVariablesNotDeclared(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/model/variables-without-decl.yml")
 	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
 	assert.EqualError(t, err,
-		`configuration.variables: Not found: "No declaration of 'HOME'"`)
+		`variables: Not found: "No declaration of 'HOME'"`)
 	assert.Nil(t, roleManifest)
 }
 
@@ -464,7 +464,7 @@ func TestLoadRoleManifestBadCVType(t *testing.T) {
 	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
 
 	require.EqualError(t, err,
-		`configuration.variables[BAR].type: Invalid value: "bogus": Expected one of user, or environment`)
+		`variables[BAR].type: Invalid value: "bogus": Expected one of user, or environment`)
 	assert.Nil(t, roleManifest)
 }
 
@@ -480,7 +480,7 @@ func TestLoadRoleManifestBadCVTypeConflictInternal(t *testing.T) {
 	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/model/bad-cv-type-internal.yml")
 	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
 	assert.EqualError(t, err,
-		`configuration.variables[BAR].type: Invalid value: "environment": type conflicts with flag "internal"`)
+		`variables[BAR].type: Invalid value: "environment": type conflicts with flag "internal"`)
 	assert.Nil(t, roleManifest)
 }
 

--- a/model/roles_test.go
+++ b/model/roles_test.go
@@ -420,6 +420,21 @@ func TestLoadRoleManifestVariablesNotDeclared(t *testing.T) {
 	assert.Nil(t, roleManifest)
 }
 
+func TestLoadRoleManifestVariablesSSH(t *testing.T) {
+	workDir, err := os.Getwd()
+	assert.NoError(t, err)
+
+	torReleasePath := filepath.Join(workDir, "../test-assets/tor-boshrelease")
+	torReleasePathBoshCache := filepath.Join(torReleasePath, "bosh-cache")
+	release, err := NewDevRelease(torReleasePath, "", "", torReleasePathBoshCache)
+	assert.NoError(t, err)
+
+	roleManifestPath := filepath.Join(workDir, "../test-assets/role-manifests/model/variables-ssh.yml")
+	roleManifest, err := LoadRoleManifest(roleManifestPath, []*Release{release}, nil)
+	assert.NoError(t, err)
+	assert.NotNil(t, roleManifest)
+}
+
 func TestLoadRoleManifestNonTemplates(t *testing.T) {
 	workDir, err := os.Getwd()
 	assert.NoError(t, err)

--- a/test-assets/role-manifests/model/variables-ssh.yml
+++ b/test-assets/role-manifests/model/variables-ssh.yml
@@ -1,0 +1,43 @@
+# This role manifest tests that an undeclared variable is an error
+---
+instance_groups:
+- name: myrole
+  run:
+    foo: x
+  jobs:
+  - name: tor
+    release: tor
+configuration:
+  templates:
+    properties.tor.ca: '((cacert)) ((cacert_KEY))'
+    properties.tor.certificate: '((FOO))((FOO_KEY))'
+    properties.tor.ssh: '((BAR))((BAR_FINGERPRINT))'
+variables:
+- name: BAR
+  type: ssh
+  options:
+    description: test
+    secret: true
+- name: BAR_FINGERPRINT
+  options:
+    secret: true
+    description: test
+- name: FOO
+  type: certificate
+  options:
+    secret: true
+    description: test
+- name: FOO_KEY
+  options:
+    secret: true
+    description: test
+- name: cacert
+  type: certificate
+  options:
+    is_ca: true
+    secret: true
+    description: test
+- name: cacert_KEY
+  options:
+    secret: true
+    description: test


### PR DESCRIPTION
We generate dependent variables for SSH and SSL secrets. This adds them to the map of all variables, so they are used correctly in the generated helm templates.

https://www.pivotaltracker.com/story/show/160310581